### PR TITLE
Add rustfmt as part of travis CI checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,4 @@ rust:
     - nightly
 before_script: (cargo install rustfmt || true)
 script:
-    - |
-    cargo fmt -- --write-mode=diff &&
-    cargo build &&
-    cargo test
+    - cargo fmt -- --write-mode=diff && cargo build && cargo test


### PR DESCRIPTION
Extends the travis config to run rustfmt and resulting in a failure if the source code does not follow the styleguide. Resolves #2 