### PR TITLE
Add automatic code coverage as part of CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,45 @@
 language: rust
 cache: cargo
+dist: trusty
+os: 
+  - linux
+
+# Run builds for all the supported trains
 rust:
-- nightly
+  - stable
+
+addons:
+  apt:
+    packages:
+      - libcurl4-openssl-dev
+      - libelf-dev
+      - libdw-dev
+      - cmake
+      - gcc
+      - binutils-dev
+      - libiberty-dev
+
 before_script: "(cargo install rustfmt || true)"
+
+# The main build
 script:
 - cargo fmt -- --write-mode=diff && cargo build && cargo test
+
+# Upload docs
 after_success: |
+  wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz &&
+  tar xzf master.tar.gz &&
+  cd kcov-master &&
+  mkdir build &&
+  cd build &&
+  cmake .. &&
+  make &&
+  make install DESTDIR=../../kcov-build &&
+  cd ../.. &&
+  rm -rf kcov-master &&
+  for file in target/debug/gemini-*[^\.d]; do mkdir -p "target/cov/$(basename $file)"; ./kcov-build/usr/local/bin/kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done &&
+  bash <(curl -s https://codecov.io/bash) &&
+  echo "Uploaded code coverage" &&
   [ $TRAVIS_BRANCH = master ] &&
   [ $TRAVIS_PULL_REQUEST = false ] &&
   cargo rustdoc -- --no-defaults --passes collapse-docs --passes unindent-comments &&

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Gemini
 ![](https://travis-ci.org/holmgr/gemini.svg?branch=master)
+[![codecov](https://codecov.io/gh/holmgr/gemini/branch/master/graph/badge.svg)](https://codecov.io/gh/holmgr/gemini)
 
 Science fiction space trading/smuggling simulation game using procedural generation.
 


### PR DESCRIPTION
### Description
This PR adds automatic code coverage reporting as part of CI build using codecov.io

### Alternate Designs
N/A

### Benefits
See regressions in terms of code coverage

### Possible Drawbacks
N/A

### Applicable Issues
N/A