### PR TITLE
Add name generation to systems

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ extern crate rayon;
 extern crate nalgebra;
 extern crate statrs;
 
-#[macro_use(info, log)]
+#[macro_use(info, debug, log)]
 extern crate log;
 extern crate env_logger;
 
@@ -31,6 +31,7 @@ fn main() {
 
     info!("Generating galaxy...");
     let mut galaxy = generate_galaxy(&config);
+    debug!("Generated galaxy: {:?}", galaxy);
 
     // Reload GameConfig if file on disk changes
     loop {
@@ -43,6 +44,7 @@ fn main() {
                 );
                 info!("Regenerating galaxy...");
                 galaxy = generate_galaxy(&config);
+                debug!("Generated galaxy: {:?}", galaxy);
             }
             Err(e) => println!("Error: {}", e),
         }


### PR DESCRIPTION
### Description
* Adds names to system by sending a mutex locked name generator to each system. 
  * Mutex is needed since generation of names mutates the generator

### Alternate Designs
N/A

### Benefits
Adds names to systems, and allows for generation of names for planets later on.

### Possible Drawbacks
N/A

### Applicable Issues
N/A