### PR TITLE
Fallback to Unnamed when no name found, fixes #30

### DIFF
--- a/src/astronomicals.rs
+++ b/src/astronomicals.rs
@@ -63,7 +63,11 @@ impl System {
 
         // Unwrap and lock name generator as it is mutated by generation
         let mut name_gen_unwraped = name_gen.lock().unwrap();
-        let name = name_gen_unwraped.generate().unwrap();
+
+        // Fallback to "Unnamed"
+        let name = name_gen_unwraped.generate().unwrap_or(
+            String::from("Unnamed"),
+        );
 
         // TODO: Planets
         let satelites = vec![];


### PR DESCRIPTION
### Description

Fallback to "Unnamed" as name for stars when NameGen fails

### Alternate Designs
Introduce some scientific notation as described in #30 this however seem to much work since this should very rarly happen.

### Benefits
No unwanted crashes

### Possible Drawbacks
Badly named systems

### Applicable Issues
#30 