### PR TITLE
Reduce default cluster size, fixes #32

### DIFF
--- a/src/game_config.rs
+++ b/src/game_config.rs
@@ -86,8 +86,8 @@ impl Default for GameConfig {
             galaxy_size: 100000.,
             number_of_clusters: 1000,
             cluster_spread: 1000.,
-            cluster_size_mean: 1000.,
-            cluster_size_std: 250.,
+            cluster_size_mean: 100.,
+            cluster_size_std: 25.,
         }
     }
 }


### PR DESCRIPTION
### Description
Sets the default cluster size to 100 and the std to 25 to produce more reasonable galaxy sizes.

### Alternate Designs
N/A

### Benefits
* Faster_ generation, no unneeded systems.
* Lower risk of running out of names

### Possible Drawbacks
N/A

### Applicable Issues
#32 