### PR TITLE
Add sector partitioning

### DIFF
--- a/src/astronomicals/mod.rs
+++ b/src/astronomicals/mod.rs
@@ -3,16 +3,17 @@ use nalgebra::geometry::Point3 as Point;
 pub mod star;
 pub mod planet;
 pub mod system;
+pub mod sector;
 
 #[derive(Debug)]
 /// Main galaxy containing all systems.
 pub struct Galaxy {
-    systems: Vec<system::System>,
+    sectors: Vec<sector::Sector>,
 }
 
 impl Galaxy {
-    pub fn new(systems: Vec<system::System>) -> Self {
-        Galaxy { systems }
+    pub fn new(sectors: Vec<sector::Sector>) -> Self {
+        Galaxy { sectors }
     }
 }
 

--- a/src/astronomicals/sector.rs
+++ b/src/astronomicals/sector.rs
@@ -1,0 +1,9 @@
+use astronomicals::system::System;
+
+/// Represents a group of systems in close proximity within the same faction.
+/// Markets in the economy is handled on this level of scale.
+#[derive(Debug)]
+pub struct Sector {
+    pub name: String,
+    pub systems: Vec<System>,
+}

--- a/src/astronomicals/system.rs
+++ b/src/astronomicals/system.rs
@@ -2,7 +2,7 @@ use nalgebra::geometry::Point3 as Point;
 use astronomicals::star::Star;
 use astronomicals::planet::Planet;
 
-#[derive(Debug, Builder)]
+#[derive(Debug, Builder, Clone)]
 /// Represets a single star system with at a given location with the given
 /// star and planets.
 pub struct System {

--- a/src/game_config.rs
+++ b/src/game_config.rs
@@ -22,6 +22,8 @@ pub struct GameConfig {
     pub cluster_spread: f64,
     pub cluster_size_mean: f64,
     pub cluster_size_std: f64,
+    pub sector_seed: u32,
+    pub max_sector_dist: f64,
 }
 
 impl GameConfig {
@@ -84,10 +86,12 @@ impl Default for GameConfig {
         GameConfig {
             map_seed: 42,
             galaxy_size: 100000.,
-            number_of_clusters: 1000,
-            cluster_spread: 1000.,
-            cluster_size_mean: 100.,
-            cluster_size_std: 25.,
+            number_of_clusters: 100,
+            cluster_spread: 10.,
+            cluster_size_mean: 1000.,
+            cluster_size_std: 250.,
+            sector_seed: 42,
+            max_sector_dist: 50.,
         }
     }
 }


### PR DESCRIPTION
### Description
* Partitions systems generated into separate sectors using a config max_distance and SCC
* Allows for assignment of factions to similar systems, i.e systems which are closed.
* Reformat some code using newer version of rustfmt

### Alternate Designs
N/A

### Benefits
Allows for easy assignment and partitioning of systems to different factions, and also lays the foundation for the economy system which should operate on sector level.

### Possible Drawbacks
Much longer generation time. From 1.8s to about 70s on my MacBook.

### Applicable Issues
N/A