### PR TITLE
Implement basic factions and faction assignment

### DIFF
--- a/src/astronomicals/sector.rs
+++ b/src/astronomicals/sector.rs
@@ -1,9 +1,11 @@
 use astronomicals::system::System;
+use entities::Faction;
 
 /// Represents a group of systems in close proximity within the same faction.
 /// Markets in the economy is handled on this level of scale.
 #[derive(Debug)]
 pub struct Sector {
     pub name: String,
+    pub faction: Faction,
     pub systems: Vec<System>,
 }

--- a/src/entities/mod.rs
+++ b/src/entities/mod.rs
@@ -1,0 +1,33 @@
+use rand::Rng;
+
+/// Represents a single Faction which is assigned on Sector level.
+#[derive(Debug)]
+pub enum Faction {
+    Empire,
+    Federation,
+    Cartel,
+    Independent,
+}
+
+impl Faction {
+    /// Generate a random faction according to the "distribution".
+    pub fn random_faction<R: Rng>(mut gen: R) -> Faction {
+        let probs = vec![
+            (Faction::Cartel, 12),
+            (Faction::Empire, 50),
+            (Faction::Federation, 30),
+            (Faction::Independent, 8),
+        ];
+
+        let mut rnd: u32 = gen.gen_range(0, 100);
+        for (fac, prob) in probs {
+            if rnd <= prob {
+                return fac;
+            } else {
+                rnd -= prob;
+            }
+        }
+        // Default faction
+        Faction::Independent
+    }
+}

--- a/src/generators/mod.rs
+++ b/src/generators/mod.rs
@@ -1,4 +1,4 @@
-use rand::{Rng, SeedableRng};
+use rand::{thread_rng, Rng, SeedableRng};
 use std::time::Instant;
 use rayon::prelude::*;
 use rand::isaac::IsaacRng;
@@ -24,6 +24,7 @@ use generators::names::NameGen;
 use generators::planets::PlanetGen;
 use astronomicals::planet::Planet;
 use astronomicals::sector::Sector;
+use entities::Faction;
 
 /// A generator that can be explicitly seeded in order to the produce the same
 /// stream of psuedo randomness each time.
@@ -264,8 +265,12 @@ pub fn into_sectors(
                 .generate()
                 .unwrap_or(String::from("Unnamed")) + " Sector";
 
+            // Set Faction for sector
+            let faction = Faction::random_faction(&mut thread_rng());
+
             Sector {
                 systems: vect,
+                faction: faction,
                 name: sector_name,
             }
         })
@@ -281,6 +286,33 @@ pub fn into_sectors(
            sectors.iter().fold(MAX, |acc, ref sec| {
                acc.min(sec.systems.len()) }),
         ((now.elapsed().as_secs() * 1_000) + (now.elapsed().subsec_nanos() / 1_000_000) as u64)
+    );
+    info!(
+        "Sectors include: {} Cartel, {} Empire, {} Federation, {} Independent",
+        sectors
+            .iter()
+            .fold(0, |acc, ref sec| acc + match sec.faction {
+                Faction::Cartel => 1,
+                _ => 0,
+            }),
+        sectors
+            .iter()
+            .fold(0, |acc, ref sec| acc + match sec.faction {
+                Faction::Empire => 1,
+                _ => 0,
+            }),
+        sectors
+            .iter()
+            .fold(0, |acc, ref sec| acc + match sec.faction {
+                Faction::Federation => 1,
+                _ => 0,
+            }),
+        sectors
+            .iter()
+            .fold(0, |acc, ref sec| acc + match sec.faction {
+                Faction::Independent => 1,
+                _ => 0,
+            })
     );
 
     sectors

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ mod game_config;
 mod resources;
 mod generators;
 mod astronomicals;
+mod entities;
 
 use generators::generate_galaxy;
 


### PR DESCRIPTION
### Description
* Implements basic Factions and faction assignment on sector level.

### Alternate Designs
Implement factions on system or planet level, however this would be inconvenient since all market trading are done on sector level so all systems in a sector can be assumed to be of the same faction.

### Benefits
Faction further builds the needed components for the economy system.

### Possible Drawbacks
N/A

### Applicable Issues
N/A