### PR TITLE
Add sector approximation functionality

### DIFF
--- a/src/game_config.rs
+++ b/src/game_config.rs
@@ -20,6 +20,8 @@ pub struct GameConfig {
     pub number_of_systems: u64,
     pub system_spread: f64,
     pub number_of_sectors: usize,
+    pub sector_approximation: bool,
+    pub num_approximation_systems: usize,
 }
 
 impl GameConfig {
@@ -84,6 +86,8 @@ impl Default for GameConfig {
             number_of_systems: 100000,
             system_spread: 200.,
             number_of_sectors: 30,
+            sector_approximation: true,
+            num_approximation_systems: 100000,
         }
     }
 }


### PR DESCRIPTION
### Description
* Implement sector approximation functionality by optionally only using a subset of systems when running k-means. Will improve speed drastically when compared to running k-means on all systems.

### Alternate Designs
N/A

### Benefits
Faster generation

### Possible Drawbacks
Worse accuracy for sectors, might not be a bad thing though.

### Applicable Issues
N/A