### PR TITLE
Generate in seperate thread to boot gui immidiately

### DIFF
--- a/src/gui/tab/map.rs
+++ b/src/gui/tab/map.rs
@@ -137,6 +137,15 @@ impl Tab for MapTab {
             },
             _ => {}
         };
+
+        // Update sizes of lists
+        let galaxy = &self.state.galaxy.lock().unwrap();
+        self.max_selected_sector = galaxy.sectors.len();
+        self.max_selected_system = galaxy.sectors[self.selected_sector].systems.len();
+        self.max_selected_astronomical = galaxy.sectors[self.selected_sector].systems
+            [self.selected_system]
+            .satelites
+            .len();
     }
 
     /// Draws the tab in the given terminal and area.

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ mod game;
 mod gui;
 
 use std::sync::Arc;
+use std::thread;
 use generators::generate_galaxy;
 
 fn main() {
@@ -42,13 +43,17 @@ fn main() {
     // Inital game state
     let game_state = game::Game::new();
 
+    let game_state_gen = game_state.clone();
+    let enable_gui = config.enable_gui;
     // Generate galaxy
-    info!("Generating galaxy...");
-    *game_state.galaxy.lock().unwrap() = generate_galaxy(&config);
+    thread::spawn(move || {
+        info!("Generating galaxy...");
+        *game_state_gen.galaxy.lock().unwrap() = generate_galaxy(&config);
+    });
 
     // Init and start gui
-    if config.enable_gui {
-        let mut gui = gui::Gui::new(game_state.clone());
+    if enable_gui {
+        let mut gui = gui::Gui::new(game_state);
         gui.start();
     }
 }


### PR DESCRIPTION
### Description

* Run the galaxy generation in a seperate thread.

### Alternate Designs
N/A

### Benefits
Allows the GUI to start immidiately instead of waiting for the generation to run.

### Possible Drawbacks
N/A

### Applicable Issues
N/A