### PR TITLE
Change distribution to given more planets, fixes #60

### DIFF
--- a/src/generators/mod.rs
+++ b/src/generators/mod.rs
@@ -154,7 +154,7 @@ pub fn generate_system(
     name_gen_unwraped.reseed(hash as u32);
 
     // TODO: Replace constant in config.
-    let num_planets = Gamma::new(1., 0.5)
+    let num_planets = Gamma::new(3.5, 1.)
         .unwrap()
         .sample::<StdRng>(&mut rng)
         .round() as u32;


### PR DESCRIPTION
### Description
Modifies the underlying gamma distribution for generating the number of planets for a system.
Will result in more populated systems in terms of number of planets.the concepts.

### Alternate Designs
N/A

### Benefits
Less zero planet systems

### Possible Drawbacks
N/A

### Applicable Issues
#60 