### PR TITLE
Implement basic ship structure and gui components

### DIFF
--- a/res/ships.json
+++ b/res/ships.json
@@ -1,0 +1,58 @@
+{
+    "ships": [
+        {
+        "name" : "Scarab",
+        "manufacturer" : "Sinclair Dynamics",
+        "kind" : "Freighter",
+        "description" : "The Scarab builds on the classic Sinclair Dynamics design of 7414 but with hyperspace capabilities. It features decent cargo for its size but lacks any type of defensive armament making it a target for any pirate. However it is still the natural choice for any low level merchant or smuggler starting out, being a jack of all trades, master of none type of ship.",
+        "integrity" : 102,
+        "size" : { "length": 16.1, "width": 21.7, "height": 5.3},
+        "mass" : 30,
+        "slots" : 1,
+        "cost" : 12000,
+        "range" : 7.93,
+        "fuel" : 2.0,
+        "cargo" : 4,
+        "detectability" : 10,
+        "maneuverability" : 20,
+        "defense" : 0,
+        "shield" : 10
+        },
+        {
+        "name" : "Shamshir",
+        "manufacturer" : "Lèon de la Serre",
+        "kind" : "Corvette",
+        "description" : "The Shamshir is a classic Lèon design which have survived the centuries, with the first production vessel being constructed in 7128. This ship offers great jump range and cargo space in a discrete, well rounded package.",
+        "integrity" : 320,
+        "size" : { "length": 40.1, "width": 25.7, "height": 9.3},
+        "mass" : 144,
+        "slots" : 3,
+        "cost" : 840000,
+        "range" : 14.72,
+        "fuel" : 32.0,
+        "cargo" : 56,
+        "detectability" : 60,
+        "maneuverability" : 40,
+        "defense" : 30,
+        "shield" : 60
+        },
+        {
+        "name" : "Dao",
+        "manufacturer" : "Lèon de la Serre",
+        "kind" : "Corvette",
+        "description" : "The Dao is the pride of Lèon de La Serre's shipyards. Originally designed by Lèon himself, the Dao represents his life's work. However, the first vessel was only produce the last century due to technological limits of the time. It represents the pinnacle of imperial might and technology with its incredible cargo space and jump range, while at the same time packing a punch.",
+        "integrity" : 840,
+        "size" : { "length": 90.0, "width": 58.4, "height": 14.2},
+        "mass" : 320,
+        "slots" : 8,
+        "cost" : 56000000,
+        "range" : 18.92,
+        "fuel" : 64.0,
+        "cargo" : 144,
+        "detectability" : 30,
+        "maneuverability" : 20,
+        "defense" : 70,
+        "shield" : 120
+        }
+    ]
+}

--- a/src/game.rs
+++ b/src/game.rs
@@ -5,12 +5,15 @@ use preferences::prefs_base_dir;
 use serde_cbor::{from_reader, to_writer};
 
 use astronomicals::Galaxy;
+use ship::Shipyard;
+use resources::{fetch_resource, ShipResource};
 
 const SAVE_PATH: &str = "gemini/saves/";
 
 /// Main game state object, shared and syncronized by use of Arc and Mutex.
 pub struct Game {
     pub galaxy: Mutex<Galaxy>,
+    pub shipyard: Mutex<Shipyard>,
 }
 
 impl Game {
@@ -18,6 +21,7 @@ impl Game {
     pub fn new() -> Arc<Self> {
         Arc::new(Game {
             galaxy: Mutex::new(Galaxy::new(vec![])),
+            shipyard: Mutex::new(Shipyard::new()),
         })
     }
 
@@ -41,9 +45,13 @@ impl Game {
             .ok()
             .and_then(|galaxy_file| from_reader(galaxy_file).ok());
 
+        let mut shipyard = Shipyard::new();
+        shipyard.add_ships(fetch_resource::<ShipResource>().unwrap());
+
         match galaxy {
             Some(g) => Some(Arc::new(Game {
                 galaxy: Mutex::new(g),
+                shipyard: Mutex::new(shipyard),
             })),
             _ => None,
         }

--- a/src/gui/tab/shipyard.rs
+++ b/src/gui/tab/shipyard.rs
@@ -1,14 +1,29 @@
 use super::*;
+use std::iter;
+use termion::event as keyevent;
+use tui::widgets::{Block, Borders, Paragraph, SelectableList, Widget};
+use tui::layout::{Direction, Group, Rect, Size};
+use tui::style::{Color, Style};
+
+use ship::ShipCharacteristics;
 
 /// Displays the shipyard tab.
 pub struct ShipyardTab {
     state: Arc<Game>,
+    selected: usize,
+    max_selected: usize,
 }
 
 impl Tab for ShipyardTab {
     /// Creates a shipyard tab.
     fn new(state: Arc<Game>) -> Box<Self> {
-        Box::new(ShipyardTab { state: state })
+        let max_selected = &state.shipyard.lock().unwrap().get_available().len();
+
+        Box::new(ShipyardTab {
+            state: state,
+            selected: 0,
+            max_selected: *max_selected - 1,
+        })
     }
 
     /// Returns the title string describing the tab.
@@ -17,8 +32,115 @@ impl Tab for ShipyardTab {
     }
 
     /// Handles the user provided event.
-    fn handle_event(&mut self, event: Event) {}
+    fn handle_event(&mut self, event: Event) {
+        match event {
+            Event::Input(input) => match input {
+                // Move up item list.
+                keyevent::Key::Char('k') => {
+                    self.selected = (self.selected as i32 - 1).max(0) as usize
+                }
+                // Move down item list.
+                keyevent::Key::Char('j') => {
+                    self.selected = (self.selected + 1).min(self.max_selected)
+                }
+
+                _ => {}
+            },
+            _ => {}
+        };
+
+        // Update sizes of lists
+        let shipyard = &self.state.shipyard.lock().unwrap();
+        self.max_selected = shipyard.get_available().len() - 1;
+    }
 
     /// Draws the tab in the given terminal and area.
-    fn draw(&self, term: &mut Terminal<MouseBackend>, area: &Rect) {}
+    fn draw(&self, term: &mut Terminal<MouseBackend>, area: &Rect) {
+        Group::default()
+            .direction(Direction::Horizontal)
+            //.sizes(&[Size::Percent(10), Size::Percent(90)])
+            .sizes(&[Size::Fixed(15), Size::Min(1)])
+            .render(term, area, |term, chunks| {
+                let ships = &self.state.shipyard.lock().unwrap().get_available().clone();
+                draw_ship_list(self.selected, ships, term, &chunks[0]);
+                draw_ship_info(&ships[self.selected], term, &chunks[1]);
+            });
+    }
+}
+
+/// Draw a list of the given ships with their names.
+fn draw_ship_list(
+    selected: usize,
+    ships: &Vec<ShipCharacteristics>,
+    term: &mut Terminal<MouseBackend>,
+    area: &Rect,
+) {
+    SelectableList::default()
+        .block(Block::default().title("Ships").borders(Borders::ALL))
+        .items(&ships
+            .iter()
+            .map(|ref ship| ship.name.clone())
+            .collect::<Vec<String>>())
+        .select(selected)
+        .style(Style::default())
+        .highlight_style(Style::default().bg(Color::White))
+        .render(term, &area);
+}
+
+/// Draw detailed ship information for a given ship.
+fn draw_ship_info(ship: &ShipCharacteristics, term: &mut Terminal<MouseBackend>, area: &Rect) {
+    let ship_data = vec![
+        ("Name", ship.name.clone()),
+        ("Manufacturer", ship.manufacturer.clone()),
+        ("Kind", ship.kind.to_string()),
+        ("Description", ship.description.clone()),
+        ("Cost", ship.cost.to_string()),
+        ("Integrity", ship.integrity.to_string()),
+        ("Size", ship.size.to_string()),
+        ("Mass", ship.mass.to_string()),
+        ("Modification slots", ship.slots.to_string()),
+        ("Jump range", ship.range.to_string()),
+        ("Fuel capacity", ship.fuel.to_string()),
+        ("Cargo capacity", ship.cargo.to_string()),
+        ("Detectability", ship.detectability.to_string()),
+        ("Maneuverability", ship.maneuverability.to_string()),
+        ("Defense", ship.defense.to_string()),
+        ("Shield", ship.shield.to_string()),
+    ];
+
+    // Manually calculate the number of rows needed for the ship description.
+    let num_description_rows = ship.description.len() as u16 / area.width + 2;
+
+    let mut row_sizes = iter::repeat(Size::Fixed(2))
+        .take(ship_data.len())
+        .collect::<Vec<_>>();
+    row_sizes[3] = Size::Fixed(num_description_rows);
+
+    Group::default()
+        .direction(Direction::Vertical)
+        .sizes(row_sizes.as_slice())
+        .margin(4)
+        .render(term, area, |term, chunks| {
+            for (index, &chunk) in chunks.iter().enumerate() {
+                // Draw a single row.
+                Group::default()
+                    .direction(Direction::Horizontal)
+                    .sizes(&[Size::Fixed(20), Size::Min(1)])
+                    .render(term, &chunk, |term, inner_chunks| {
+                        let (characteristic, ref value) = ship_data[index];
+                        Paragraph::default()
+                            .block(Block::default())
+                            .style(Style::default().fg(Color::White))
+                            .wrap(false)
+                            .text(characteristic)
+                            .render(term, &inner_chunks[0]);
+                        Paragraph::default()
+                            .block(Block::default())
+                            .style(Style::default().fg(Color::White))
+                            .wrap(true)
+                            .text(value.as_str())
+                            .render(term, &inner_chunks[1]);
+                    });
+            }
+        });
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,7 @@ mod entities;
 mod game;
 mod gui;
 mod event;
+mod ship;
 
 use generators::generate_galaxy;
 
@@ -53,6 +54,13 @@ fn main() {
             // Generate galaxy
             info!("Generating galaxy...");
             *game_state.galaxy.lock().unwrap() = generate_galaxy(&config);
+
+            info!("Loading ships...");
+            game_state
+                .shipyard
+                .lock()
+                .unwrap()
+                .add_ships(resources::fetch_resource::<resources::ShipResource>().unwrap());
             game_state.save();
             game_state
         }

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -3,6 +3,8 @@ use serde_json;
 use serde::de::Deserialize;
 use std::collections::HashMap;
 
+use ship::ShipCharacteristics;
+
 /// Generic Resource trait to be implemented by all resource types which should
 /// be loaded at compile time.
 /// KEY must be unique to the specific resource (e.g the filename of the
@@ -19,6 +21,10 @@ lazy_static! {
         res.insert(
             AstronomicalNamesResource::KEY,
             include_str!("../res/astronomical_names.json"),
+        );
+        res.insert(
+            ShipResource::KEY,
+            include_str!("../res/ships.json"),
         );
         res
     };
@@ -42,6 +48,16 @@ pub struct AstronomicalNamesResource {
 
 impl Resource for AstronomicalNamesResource {
     const KEY: &'static str = "astronomical_names";
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+/// Resource of all ships available in the game.
+pub struct ShipResource {
+    pub ships: Vec<ShipCharacteristics>,
+}
+
+impl Resource for ShipResource {
+    const KEY: &'static str = "ships";
 }
 
 #[cfg(test)]

--- a/src/ship/mod.rs
+++ b/src/ship/mod.rs
@@ -1,0 +1,88 @@
+use std::fmt;
+use resources::ShipResource;
+
+/// Ship currently owned by the player.
+pub struct Ship {
+    integrity: u32,
+    fuel: f32,
+    base: ShipCharacteristics,
+}
+
+impl Ship {}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+/// Represents the characteristics of a given ship model.
+pub struct ShipCharacteristics {
+    pub name: String,
+    pub manufacturer: String,
+    pub kind: ShipType,
+    pub description: String,
+    pub integrity: u32,
+    pub size: Dimensions,
+    pub mass: u32,
+    pub slots: u32,
+    pub cost: u32,
+    pub range: f32,
+    pub fuel: f32,
+    pub cargo: u32,
+    pub detectability: u32,
+    pub maneuverability: u32,
+    pub defense: u32,
+    pub shield: u32,
+}
+
+impl ShipCharacteristics {}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum ShipType {
+    Assault,
+    Corvette,
+    Freighter,
+}
+
+impl fmt::Display for ShipType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            &ShipType::Assault => write!(f, "Assault Ship"),
+            &ShipType::Corvette => write!(f, "Light Corvette"),
+            &ShipType::Freighter => write!(f, "Light Freighter"),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+/// The size of a ship.
+pub struct Dimensions {
+    length: f32,
+    width: f32,
+    height: f32,
+}
+
+impl fmt::Display for Dimensions {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}L, {}W, {}H", self.length, self.width, self.height)
+    }
+}
+
+/// Holds the different ships in the game.
+pub struct Shipyard {
+    ships: Vec<ShipCharacteristics>,
+}
+
+impl Shipyard {
+    /// Returns a new shipyard.
+    pub fn new() -> Shipyard {
+        Shipyard { ships: vec![] }
+    }
+
+    /// Extend shipyard with more ships.
+    pub fn add_ships(&mut self, resource: ShipResource) {
+        self.ships.extend(resource.ships);
+    }
+
+    /// Get all available ships.
+    pub fn get_available(&self) -> &Vec<ShipCharacteristics> {
+        // TODO: Base the return value on the caller, i.e the faction, system etc.
+        &self.ships
+    }
+}


### PR DESCRIPTION
### Description
This PR adds:
* Add initial ship resources (3 ships)
* Implement basic ship types
* Loading of ships on game start
* Flesh out the shipyard tab

### Alternate Designs
N/A

### Benefits
Shipyard and ships :) Lays the ground work for the player type and travel.

### Possible Drawbacks
N/A

### Applicable Issues
#67 