### PR TITLE
Rework galaxy architecture to be more flexible for spatial queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,21 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cgmath"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "clamp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,6 +243,7 @@ dependencies = [
  "serde_cbor 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spade 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "statrs 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -413,10 +429,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-bigint 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-complex 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-iter 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-rational 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-bigint 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -455,6 +525,11 @@ dependencies = [
 [[package]]
 name = "ordermap"
 version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "pdqselect"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -606,6 +681,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "serde"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "serde_cbor"
@@ -670,6 +748,25 @@ dependencies = [
 name = "slab"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "smallvec"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "spade"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cgmath 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clamp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nalgebra 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pdqselect 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "statrs"
@@ -874,6 +971,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c129aff112dcc562970abb69e2508b40850dd24c274761bb50fb8a0067ba6c27"
 "checksum cassowary 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
+"checksum cgmath 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6f3f4e27f2647652606e9faab058dd8686513a23b276fcd16e85eb0927838ddc"
+"checksum clamp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b0113a8ae379a061c89a71d57a809439f5ce550b6a76063ab5ba2b1cb180971f"
 "checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
 "checksum crossbeam-epoch 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "59796cc6cbbdc6bb319161349db0c3250ec73ec7fcb763a51065ec4e2e158552"
 "checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
@@ -908,12 +1007,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum nix 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bfb3ddedaa14746434a02041940495bf11325c22f6d36125d3bdd56090d50a79"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum notify 4.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5c3812da3098f210a0bb440f9c008471a031aa4c1de07a264fdd75456c95a4eb"
+"checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
+"checksum num-bigint 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "81b483ea42927c463e191802e7334556b48e7875297564c0e9951bd3a0ae53e3"
 "checksum num-complex 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "26ff8edeab9f1d8cf6b595e35138c2a389ea29f4f57a0e6bc44abf406e4b0077"
+"checksum num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f8d26da319fb45674985c78f1d1caf99aa4941f785d384a2ae36d0740bc3e2fe"
+"checksum num-iter 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "4b226df12c5a59b63569dd57fafb926d91b385dfce33d8074a412411b689d593"
+"checksum num-rational 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "ee314c74bd753fc86b4780aa9475da469155f3848473a261d2d18e35245a784e"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 "checksum num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e7de20f146db9d920c45ee8ed8f71681fd9ade71909b48c3acbd766aa504cf10"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2c49021782e5233cd243168edfa8037574afed4eba4bbaf538b3d8d1789d8c"
 "checksum ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
+"checksum pdqselect 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ec91767ecc0a0bbe558ce8c9da33c068066c57ecc8bb8477ef8c1ad3ef77c27"
 "checksum petgraph 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "7a7e5234c228fbfa874c86a77f685886127f82e0aef602ad1d48333fcac6ad61"
 "checksum preferences 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "da724bda86ecf80904babc11b0ca492e83987a3d735b48b8ff19688ce330605a"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
@@ -941,6 +1046,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c9db7266c7d63a4c4b7fe8719656ccdd51acf1bed6124b174f933b009fb10bcb"
 "checksum shell32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9ee04b46101f57121c9da2b151988283b6beb79b34f5bb29a58ee48cb695122c"
 "checksum slab 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d807fd58c4181bbabed77cb3b891ba9748241a552bcc5be698faaebefc54f46e"
+"checksum smallvec 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4f8266519bc1d17d0b5b16f6c21295625d562841c708f6376f49028a43e9c11e"
+"checksum spade 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7acaf24b56259a7215446640e34558e7329f6a23107dfc5168a9e9236528610"
 "checksum statrs 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d8c8660e3867d1a0578cbf7fd9532f1368b7460bd00b080e2d4669618a9bec7"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ termion = "1.5.1"
 Inflector = "^0.11"
 serde_cbor = "0.8.2"
 toml = "0.4.5"
+spade = { version = "1.4.0", features = ["serde_serialize"] }

--- a/src/astronomicals/mod.rs
+++ b/src/astronomicals/mod.rs
@@ -1,4 +1,4 @@
-use nalgebra::geometry::Point3 as Point;
+use utils::Point;
 
 pub mod star;
 pub mod planet;
@@ -19,7 +19,7 @@ impl Galaxy {
 
 /// Hash based on location, algorithm used is presented in the paper:
 /// Optimized Spatial Hashing for Collision Detection of Deformable Objects.
-pub fn hash(location: Point<f64>) -> u64 {
+pub fn hash(location: &Point) -> u64 {
     let values = location
         .iter()
         .zip(&[73856093f64, 19349663f64, 83492791f64])

--- a/src/astronomicals/mod.rs
+++ b/src/astronomicals/mod.rs
@@ -1,4 +1,8 @@
-use utils::Point;
+use std::collections::HashMap;
+use spade::rtree::RTree;
+use nalgebra::distance;
+
+use utils::{HashablePoint, Point};
 
 pub mod star;
 pub mod planet;
@@ -6,14 +10,72 @@ pub mod system;
 pub mod sector;
 
 /// Main galaxy containing all systems.
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Galaxy {
     pub sectors: Vec<sector::Sector>,
+    pub map: RTree<HashablePoint>,
+    pub systems: HashMap<HashablePoint, system::System>,
 }
 
 impl Galaxy {
-    pub fn new(sectors: Vec<sector::Sector>) -> Self {
-        Galaxy { sectors }
+    /// Create a new Galaxy with the given sectors and systems.
+    pub fn new(sectors: Vec<sector::Sector>, systems: Vec<system::System>) -> Self {
+        let mut map = RTree::new();
+        systems
+            .iter()
+            .for_each(|ref system| map.insert(HashablePoint::new(system.location.clone())));
+
+        let mut systems_map = HashMap::new();
+
+        for system in systems {
+            systems_map.insert(HashablePoint::new(system.location.clone()), system);
+        }
+
+        Galaxy {
+            sectors,
+            map,
+            systems: systems_map,
+        }
+    }
+
+    /// Returns a reference system at the given location if it exists.
+    pub fn system(&self, location: &Point) -> Option<&system::System> {
+        self.systems.get(&HashablePoint::new(location.clone()))
+    }
+
+    /// Returns a mutable reference system at the given location if it exists.
+    pub fn system_mut(&mut self, location: &Point) -> Option<&mut system::System> {
+        self.systems.get_mut(&HashablePoint::new(location.clone()))
+    }
+
+    /// Returns references to all systems.
+    pub fn systems(&self) -> Vec<&system::System> {
+        self.systems.values().collect::<Vec<_>>()
+    }
+
+    /// Returns references to all systems ordered by distance to the given point.
+    pub fn systems_ordered(&self, location: &Point) -> Vec<&system::System> {
+        let mut systems = self.systems.values().collect::<Vec<_>>();
+        systems.sort_unstable_by(|a, b| {
+            distance(location, &a.location)
+                .partial_cmp(&distance(location, &b.location))
+                .unwrap()
+        });
+        systems
+    }
+
+    /// Returns mutable references to all systems.
+    pub fn systems_mut(&mut self) -> Vec<&mut system::System> {
+        self.systems.values_mut().collect::<Vec<_>>()
+    }
+
+    /// Returns all system locations reachable from the given location within the given radius.
+    pub fn reachable(&self, location: &Point, max_distance: f64) -> Vec<&Point> {
+        self.map
+            .lookup_in_circle(&HashablePoint::new(location.clone()), &max_distance.sqrt())
+            .iter()
+            .map(|hashpoint| hashpoint.as_point())
+            .collect::<Vec<_>>()
     }
 }
 

--- a/src/astronomicals/sector.rs
+++ b/src/astronomicals/sector.rs
@@ -1,6 +1,5 @@
-use nalgebra::geometry::Point3 as Point;
+use utils::Point;
 
-use astronomicals::system::System;
 use entities::Faction;
 
 /// Represents a group of systems in close proximity within the same faction.
@@ -9,14 +8,16 @@ use entities::Faction;
 pub struct Sector {
     pub name: String,
     pub faction: Faction,
-    pub systems: Vec<System>,
+    pub system_locations: Vec<Point>,
 }
 
 impl Sector {
     /// Returns the point representing the centroid of the cluster.
-    pub fn center(&self) -> Point<f64> {
-        self.systems.iter().fold(Point::origin(), |center, system| {
-            center + (system.location.coords / (self.systems.len() as f64))
-        })
+    pub fn center(&self) -> Point {
+        self.system_locations
+            .iter()
+            .fold(Point::origin(), |center, system| {
+                center + (system.coords / (self.system_locations.len() as f64))
+            })
     }
 }

--- a/src/astronomicals/system.rs
+++ b/src/astronomicals/system.rs
@@ -1,5 +1,5 @@
 use std::hash::{Hash, Hasher};
-use nalgebra::geometry::Point3 as Point;
+use utils::Point;
 use astronomicals::hash;
 use astronomicals::star::Star;
 use astronomicals::planet::Planet;
@@ -8,7 +8,7 @@ use astronomicals::planet::Planet;
 /// Represets a single star system with at a given location with the given
 /// star and planets.
 pub struct System {
-    pub location: Point<f64>,
+    pub location: Point,
     pub name: String,
     pub star: Star,
     pub satelites: Vec<Planet>,
@@ -16,7 +16,7 @@ pub struct System {
 
 impl Hash for System {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        hash(self.location).hash(state);
+        hash(&self.location).hash(state);
     }
 }
 

--- a/src/astronomicals/system.rs
+++ b/src/astronomicals/system.rs
@@ -1,5 +1,6 @@
 use std::hash::{Hash, Hasher};
 use utils::Point;
+use entities::Faction;
 use astronomicals::hash;
 use astronomicals::star::Star;
 use astronomicals::planet::Planet;
@@ -10,6 +11,7 @@ use astronomicals::planet::Planet;
 pub struct System {
     pub location: Point,
     pub name: String,
+    pub faction: Faction,
     pub star: Star,
     pub satelites: Vec<Planet>,
 }

--- a/src/game.rs
+++ b/src/game.rs
@@ -20,7 +20,7 @@ impl Game {
     /// Creates a new game.
     pub fn new() -> Arc<Self> {
         Arc::new(Game {
-            galaxy: Mutex::new(Galaxy::new(vec![])),
+            galaxy: Mutex::new(Galaxy::new(vec![], vec![])),
             shipyard: Mutex::new(Shipyard::new()),
         })
     }

--- a/src/generators/mod.rs
+++ b/src/generators/mod.rs
@@ -3,7 +3,6 @@ use std::time::Instant;
 use std::collections::HashMap;
 use rayon::prelude::*;
 use statrs::distribution::{Distribution, Gamma, Normal};
-use nalgebra::geometry::Point3 as Point;
 use nalgebra::distance;
 use std::sync::{Arc, Mutex};
 use std::usize::MAX;
@@ -13,6 +12,7 @@ pub mod names;
 pub mod stars;
 pub mod planets;
 
+use utils::Point;
 use resources::{fetch_resource, AstronomicalNamesResource};
 use astronomicals::{hash, Galaxy};
 use astronomicals::system::{System, SystemBuilder};
@@ -137,13 +137,13 @@ pub fn generate_galaxy(config: &GameConfig) -> Galaxy {
 
 /// Generate a new star system using the given generators and a location as seed.
 pub fn generate_system(
-    location: Point<f64>,
+    location: Point,
     name_gen: Arc<Mutex<NameGen>>,
     star_gen: &StarGen,
     planet_gen: &PlanetGen,
 ) -> System {
     // Calculate hash.
-    let hash = hash(location);
+    let hash = hash(&location);
     let seed: &[_] = &[hash as usize];
     let mut rng: StdRng = SeedableRng::from_seed(seed);
 

--- a/src/generators/mod.rs
+++ b/src/generators/mod.rs
@@ -106,18 +106,21 @@ pub fn generate_galaxy(config: &GameConfig) -> Galaxy {
     // Generate systems for each cluster in parallel.
     // Fold will generate one vector per thread (per cluster), reduce will
     // combine them to the final result.
-    let systems = locations
-        .into_par_iter()
+    let systems = sectors
+        .par_iter()
         .fold(
             || Vec::<System>::new(),
-            |mut systems: Vec<System>, location| {
-                // Generate system
-                systems.push(generate_system(
-                    location,
-                    name_gen.clone(),
-                    &star_gen,
-                    &planet_gen,
-                ));
+            |mut systems: Vec<System>, sector| {
+                for location in &sector.system_locations {
+                    // Generate system
+                    systems.push(generate_system(
+                        location.clone(),
+                        sector.faction.clone(),
+                        name_gen.clone(),
+                        &star_gen,
+                        &planet_gen,
+                    ));
+                }
                 systems
             },
         )
@@ -148,6 +151,7 @@ pub fn generate_galaxy(config: &GameConfig) -> Galaxy {
 /// Generate a new star system using the given generators and a location as seed.
 pub fn generate_system(
     location: Point,
+    faction: Faction,
     name_gen: Arc<Mutex<NameGen>>,
     star_gen: &StarGen,
     planet_gen: &PlanetGen,
@@ -202,6 +206,7 @@ pub fn generate_system(
     SystemBuilder::default()
         .location(location)
         .name(name)
+        .faction(faction)
         .star(star)
         .satelites(satelites)
         .build()

--- a/src/gui/tab/map.rs
+++ b/src/gui/tab/map.rs
@@ -134,7 +134,7 @@ impl Tab for MapTab {
             .render(term, area, |term, chunks| match self.level {
                 Level::Galaxy => {
                     // TODO: Sort based on player location.
-                    let systems = &galaxy.systems_ordered(&Point::origin());
+                    let systems = &galaxy.systems();
                     draw_galaxy_table(self.selected_system, &systems, term, &chunks[0]);
                     draw_galaxy_map(self.selected_system, &systems, term, &chunks[1]);
                 }

--- a/src/gui/tab/map.rs
+++ b/src/gui/tab/map.rs
@@ -154,18 +154,19 @@ fn draw_galaxy_table(
     area: &Rect,
 ) {
     Table::new(
-        ["System", "Bodies"].into_iter(),
+        ["System", "Faction", "Bodies"].into_iter(),
         systems
             .iter()
             .enumerate()
             .map(|(idx, ref system)| {
-                let style: &Style = match selected == idx {
+                let style = match selected == idx {
                     true => &SELECTED_STYLE,
-                    false => &DEFAULT_STYLE,
+                    false => FACTION_STYLES.get(&system.faction).unwrap(),
                 };
                 Row::StyledData(
                     vec![
                         system.name.clone(),
+                        system.faction.to_string(),
                         (system.satelites.len() as u32).to_string(),
                     ].into_iter(),
                     &style,
@@ -197,7 +198,12 @@ fn draw_galaxy_map(
         .block(Block::default().title("Systems").borders(Borders::ALL))
         .paint(|ctx| {
             for (idx, system) in systems.iter().enumerate() {
-                let color = Color::White;
+                let color = match system.faction {
+                    Faction::Empire => Color::Red,
+                    Faction::Federation => Color::Yellow,
+                    Faction::Cartel => Color::Magenta,
+                    Faction::Independent => Color::LightGreen,
+                };
                 match idx == selected {
                     true => ctx.print(
                         system.location.coords.x,

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ extern crate serde_cbor;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_json;
+extern crate spade;
 extern crate statrs;
 extern crate termion;
 extern crate toml;

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ mod game;
 mod gui;
 mod event;
 mod ship;
+mod utils;
 
 use generators::generate_galaxy;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,4 @@
+use nalgebra::geometry::Point3;
+
+/// Alias for 3D Point from nalgebra.
+pub type Point = Point3<f64>;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,49 @@
+use std::hash::{Hash, Hasher};
+
 use nalgebra::geometry::Point3;
+use spade::PointN;
 
 /// Alias for 3D Point from nalgebra.
 pub type Point = Point3<f64>;
+
+/// Wrapper type implementing hashing for Point etc.
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+pub struct HashablePoint(Point);
+
+impl HashablePoint {
+    pub fn as_point(&self) -> &Point {
+        &self.0
+    }
+}
+
+impl Hash for HashablePoint {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0
+            .iter()
+            .zip(&[73856093f64, 19349663f64, 83492791f64])
+            .map(|(&a, &b)| (a * b) as u64)
+            .fold(0, |acc, val| acc ^ val)
+            .hash(state);
+    }
+}
+
+impl PointN for HashablePoint {
+    type Scalar = f64;
+
+    fn dimensions() -> usize {
+        3
+    }
+
+    fn nth(&self, index: usize) -> &Self::Scalar {
+        &(self.0)[index]
+    }
+    fn nth_mut(&mut self, index: usize) -> &mut Self::Scalar {
+        &mut (self.0)[index]
+    }
+
+    fn from_value(value: Self::Scalar) -> HashablePoint {
+        HashablePoint {
+            0: Point::new(value, value, value),
+        }
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -11,6 +11,9 @@ pub type Point = Point3<f64>;
 pub struct HashablePoint(Point);
 
 impl HashablePoint {
+    pub fn new(point: Point) -> HashablePoint {
+        HashablePoint { 0: point }
+    }
     pub fn as_point(&self) -> &Point {
         &self.0
     }
@@ -26,6 +29,8 @@ impl Hash for HashablePoint {
             .hash(state);
     }
 }
+
+impl Eq for HashablePoint {}
 
 impl PointN for HashablePoint {
     type Scalar = f64;


### PR DESCRIPTION
### Description
Rework the galaxy architecture to be based around system locations (Points).
By moving systems directly out of sectors to an hashmap, and an R*-tree and only keeping system locations in the sectors we can have good spatial queries while at the same time work on the entire system set.

### Alternate Designs
N/A

### Benefits
Spatial queries.

### Possible Drawbacks
N/A

### Applicable Issues
N/A