### PR TITLE
Implement basic status tab, resolves #70

### DIFF
--- a/src/gui/tab/status.rs
+++ b/src/gui/tab/status.rs
@@ -1,4 +1,8 @@
 use super::*;
+use player::Player;
+use tui::widgets::{Block, Borders, Paragraph, SelectableList, Widget};
+use tui::layout::{Direction, Group, Rect, Size};
+use tui::style::{Color, Style};
 
 /// Displays the status tab.
 pub struct StatusTab {
@@ -20,5 +24,82 @@ impl Tab for StatusTab {
     fn handle_event(&mut self, event: Event) {}
 
     /// Draws the tab in the given terminal and area.
-    fn draw(&self, term: &mut Terminal<MouseBackend>, area: &Rect) {}
+    fn draw(&self, term: &mut Terminal<MouseBackend>, area: &Rect) {
+        Group::default()
+            .direction(Direction::Horizontal)
+            .sizes(&[Size::Fixed(38), Size::Min(1)])
+            .render(term, area, |term, chunks| {
+                let player = &self.state.player.lock().unwrap();
+                draw_player_info(&player, term, &chunks[0]);
+            });
+    }
+}
+
+/// Draw detailed player information.
+fn draw_player_info(player: &Player, term: &mut Terminal<MouseBackend>, area: &Rect) {
+    // Data fields to be displayed in a table like format.
+    let ship = player.ship();
+    let player_data = vec![
+        format!("Balance:   {} CR", player.balance().to_string()),
+        format!(
+            "Ship:      {}",
+            match ship {
+                &Some(ref ship) => ship.characteristics().name.clone(),
+                &None => String::from("None"),
+            }
+        ),
+        format!(
+            "   Integrity: {}",
+            match ship {
+                &Some(ref ship) => ship.integrity().to_string(),
+                &None => String::from("-"),
+            }
+        ),
+        format!(
+            "   Fuel:      {}",
+            match ship {
+                &Some(ref ship) => ship.fuel().to_string(),
+                &None => String::from("-"),
+            }
+        ),
+    ];
+
+    // TODO: Move image to resource file.
+    let commander_image = ",,,,,,,,,,,,,,,,,\",,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,Ii!!I:,,,,,,,,,,,,,
+,,,,,,,,,,,,,,;!<+______>I:,\",,,,,,,,
+,,,,,,,,,,\"\";l>_<!l;;IIl!<iI:,\",,,,,,
+,,,,,,,,,,;l>++_<!I,,,,,;lI;:,,,,,,,,
+,,,,,,,,,,;!<+~>!I;:,\",:,\"\"\",,,,,,,,,
+,,,,,,,,,,,:Il!>iil;IllIlllll;:,,,,,,
+,,,,,,,,,,,:::I!>~i;I!lIIl>+<I:,\",,,,
+,,,,,,,,,,,,::::,,,,,:,,,,I>>l;,,,,,,
+,,,,,,,,,,,,,,,::;:::::,,:l<>l:,\",,,,
+,,,,,,,,,,,,,:::,,,,:;::Ii<+<I:,\",,,,
+,,,,,,,,,,,,,:::,\",,,:::l<>l;,,,,,,,,
+,,,,,,,,,,,,:;;;;::,,:::l<iI:,\",,,,,,
+,,,,,,,,,,,,,,::!<i!I;;I;;:,,,,,,,,,,
+,,,,,,,,,,,,,,,,:II;;;::,\"\",,,,,,,,,,
+,,,,,,,,,,,,::,,,:::;;;:,,,,,,,,,,,,,
+,,,,,,,,,,:::::::,,,;lII:,,,,,,,,,,,,
+,,,,,,,,,:::::::,,:;:,;II;:,,,,,,,,,,
+,,,,,,::::::::::::::::;I;:,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,";
+
+    Group::default()
+        .direction(Direction::Vertical)
+        .sizes(&[Size::Fixed(20), Size::Min(1)])
+        .render(term, area, |term, chunks| {
+            Paragraph::default()
+                .block(Block::default().title("Commander").borders(Borders::ALL))
+                .style(Style::default().fg(Color::Yellow))
+                .wrap(false)
+                .text(commander_image)
+                .render(term, &chunks[0]);
+            SelectableList::default()
+                .items(&player_data)
+                .block(Block::default().borders(Borders::ALL))
+                .style(Style::default().fg(Color::Yellow))
+                .render(term, &chunks[1]);
+        });
 }

--- a/src/player.rs
+++ b/src/player.rs
@@ -15,6 +15,16 @@ impl Player {
             ship: Some(ship),
         }
     }
+
+    /// Returns the player's current balance.
+    pub fn balance(&self) -> u32 {
+        self.credits
+    }
+
+    /// Returns an reference to the player's active ship.
+    pub fn ship(&self) -> &Option<Ship> {
+        &self.ship
+    }
 }
 
 impl Default for Player {

--- a/src/ship/mod.rs
+++ b/src/ship/mod.rs
@@ -17,6 +17,21 @@ impl Ship {
             base: model,
         }
     }
+
+    /// Returns a reference to the ship's current integrity.
+    pub fn integrity(&self) -> &u32 {
+        &self.integrity
+    }
+
+    /// Returns a reference to the ship's current fuel.
+    pub fn fuel(&self) -> &f32 {
+        &self.fuel
+    }
+
+    /// Returns a reference to the ship's characteristics.
+    pub fn characteristics(&self) -> &ShipCharacteristics {
+        &self.base
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]


### PR DESCRIPTION
### Description
Implement basic status tab showing basic player information such as fuel and ship integrity. Also a basic "profile picture" is shown also in ASCII.

### Alternate Designs
N/A

### Benefits
N/A

### Possible Drawbacks
N/A

### Applicable Issues
#70 