### PR TITLE
Rework galaxy map, move to 2d system space

### DIFF
--- a/src/astronomicals/mod.rs
+++ b/src/astronomicals/mod.rs
@@ -77,6 +77,13 @@ impl Galaxy {
             .map(|hashpoint| hashpoint.as_point())
             .collect::<Vec<_>>()
     }
+
+    /// Returns the nearest system location to the given point.
+    pub fn nearest(&self, location: &Point) -> Option<&Point> {
+        self.map
+            .nearest_neighbor(&HashablePoint::new(location.clone()))
+            .map(|p| p.as_point())
+    }
 }
 
 /// Hash based on location, algorithm used is presented in the paper:

--- a/src/generators/mod.rs
+++ b/src/generators/mod.rs
@@ -71,7 +71,6 @@ pub fn generate_galaxy(config: &GameConfig) -> Galaxy {
     // Clusters are spaced uniformly, systems gaussian.
     let loc_x = Normal::new(0., config.system_spread).unwrap();
     let loc_y = Normal::new(0., config.system_spread).unwrap();
-    let loc_z = Normal::new(0., config.system_spread / 10.).unwrap();
 
     // Generate system locations.
     let mut locations = vec![];
@@ -79,7 +78,6 @@ pub fn generate_galaxy(config: &GameConfig) -> Galaxy {
         locations.push(Point::new(
             loc_x.sample::<ChaChaRng>(&mut rng),
             loc_y.sample::<ChaChaRng>(&mut rng),
-            loc_z.sample::<ChaChaRng>(&mut rng),
         ))
     }
 

--- a/src/gui/tab/map.rs
+++ b/src/gui/tab/map.rs
@@ -2,60 +2,49 @@ use super::*;
 use std::collections::HashMap;
 use termion::event as keyevent;
 
+use nalgebra::{distance, Vector2};
 use utils::Point;
 use entities::Faction;
 use astronomicals::system::System;
-use tui::widgets::{Block, Borders, Row, Table, Widget};
+use tui::widgets::{Block, Borders, Row, SelectableList, Table, Widget};
 use tui::widgets::canvas::Canvas;
 use tui::layout::{Direction, Group, Rect, Size};
 use tui::style::{Color, Style};
 
-/// Level of map display.
-enum Level {
-    Galaxy,
-    System,
-}
-
 lazy_static! {
     /// Color mapping for each faction.
-    static ref FACTION_STYLES: HashMap<Faction, Style> = {
+    static ref FACTION_COLORS: HashMap<Faction, Color> = {
         let mut m = HashMap::new();
-        m.insert(Faction::Empire, Style::default().fg(Color::Red));
-        m.insert(Faction::Federation, Style::default().fg(Color::Yellow));
-        m.insert(Faction::Cartel, Style::default().fg(Color::Magenta));
-        m.insert(Faction::Independent, Style::default().fg(Color::LightGreen));
+        m.insert(Faction::Empire, Color::Red);
+        m.insert(Faction::Federation, Color::Yellow);
+        m.insert(Faction::Cartel, Color::Magenta);
+        m.insert(Faction::Independent, Color::LightGreen);
         m
     };
-
-    /// Styling for selected item.
-    static ref SELECTED_STYLE: Style = Style::default().bg(Color::Gray);
 
     /// Styling for unselected item.
     static ref DEFAULT_STYLE: Style = Style::default();
 }
 
+/// The minimum distance within which the gui will snap to the closest system.
+const MIN_SNAP_DIST: f64 = 0.9;
+
 /// Displays the map tab.
 pub struct MapTab {
     state: Arc<Game>,
-    level: Level,
-    selected_system: usize,
-    max_selected_system: usize,
-    selected_astronomical: usize,
-    max_selected_astronomical: usize,
+    selected: Option<Point>,
+    cursor: Point,
+    map_scale: f64,
 }
 
 impl Tab for MapTab {
     /// Creates a map tab.
     fn new(state: Arc<Game>) -> Box<Self> {
-        let max_selected_system = state.galaxy.lock().unwrap().systems().len();
-
         Box::new(MapTab {
             state: state,
-            level: Level::Galaxy,
-            selected_system: 0,
-            max_selected_system: max_selected_system,
-            selected_astronomical: 0,
-            max_selected_astronomical: 0,
+            selected: None,
+            cursor: Point::origin(),
+            map_scale: 1.,
         })
     }
 
@@ -67,62 +56,52 @@ impl Tab for MapTab {
     /// Handles the user provided event.
     fn handle_event(&mut self, event: Event) {
         match event {
-            Event::Input(input) => match input {
-                // Move up item list.
-                keyevent::Key::Char('k') => match self.level {
-                    Level::Galaxy => {
-                        self.selected_system = (self.selected_system as i32 - 1).max(0) as usize
-                    }
-                    Level::System => {
-                        self.selected_astronomical =
-                            (self.selected_astronomical as i32 - 1).max(0) as usize
-                    }
-                },
+            Event::Input(input) => {
+                self.map_scale *= match input {
+                    // Zoom out.
+                    keyevent::Key::Char('u') => 0.5,
+                    // Zoom in.
+                    keyevent::Key::Char('i') => 2.,
 
-                // Move down item list.
-                keyevent::Key::Char('j') => match self.level {
-                    Level::Galaxy => {
-                        self.selected_system =
-                            (self.selected_system + 1).min(self.max_selected_system)
-                    }
-                    Level::System => {
-                        self.selected_astronomical =
-                            (self.selected_astronomical + 1).min(self.max_selected_astronomical)
-                    }
-                },
+                    // No zooming.
+                    _ => 1.,
+                };
 
-                // Move into item.
-                keyevent::Key::Char('l') => {
-                    self.level = match self.level {
-                        Level::Galaxy => {
-                            self.max_selected_astronomical =
-                                self.state.galaxy.lock().unwrap().systems()[self.selected_system]
-                                    .satelites
-                                    .len();
-                            Level::System
-                        }
-                        _ => Level::System,
-                    };
+                // Prevent zooming too far in.
+                self.map_scale = self.map_scale.min(4.);
+
+                let translation = match input {
+                    // Move up.
+                    keyevent::Key::Char('k') => Vector2::new(0., 1. / self.map_scale),
+                    // Move down.
+                    keyevent::Key::Char('j') => Vector2::new(0., -1. / self.map_scale),
+                    // Move right.
+                    keyevent::Key::Char('l') => Vector2::new(1. / self.map_scale, 0.),
+                    // Move left.
+                    keyevent::Key::Char('h') => Vector2::new(-1. / self.map_scale, 0.),
+                    _ => Vector2::new(0., 0.),
+                };
+
+                // Move out of snapping system if currently snapped.
+                self.cursor += match self.selected {
+                    Some(_) => Vector2::new(
+                        translation.x * 1.1 * self.map_scale * MIN_SNAP_DIST,
+                        translation.y * 1.1 * self.map_scale * MIN_SNAP_DIST,
+                    ),
+                    None => translation,
+                };
+                self.selected = None;
+
+                // Check if cursor should snap to closest system.
+                if let Some(neighbor) = self.state.galaxy.lock().unwrap().nearest(&self.cursor) {
+                    if distance(&self.cursor, &neighbor) < MIN_SNAP_DIST {
+                        self.cursor = neighbor.clone();
+                        self.selected = Some(neighbor.clone());
+                    }
                 }
-
-                // Move out of item.
-                keyevent::Key::Char('h') => {
-                    self.level = match self.level {
-                        _ => Level::Galaxy,
-                    };
-                }
-                _ => {}
-            },
+            }
             _ => {}
         };
-
-        // Update sizes of lists
-        let galaxy = &self.state.galaxy.lock().unwrap();
-        self.max_selected_system = galaxy.systems.len();
-        self.selected_system = self.selected_system.min(self.max_selected_system - 1);
-        self.max_selected_astronomical = galaxy.systems()[self.selected_system].satelites.len();
-        self.selected_astronomical = self.selected_astronomical
-            .min(self.max_selected_astronomical - 1);
     }
 
     /// Draws the tab in the given terminal and area.
@@ -130,142 +109,92 @@ impl Tab for MapTab {
         let galaxy = self.state.galaxy.lock().unwrap();
         Group::default()
             .direction(Direction::Horizontal)
-            .sizes(&[Size::Percent(30), Size::Percent(70)])
-            .render(term, area, |term, chunks| match self.level {
-                Level::Galaxy => {
-                    // TODO: Sort based on player location.
-                    let systems = &galaxy.systems();
-                    draw_galaxy_table(self.selected_system, &systems, term, &chunks[0]);
-                    draw_galaxy_map(self.selected_system, &systems, term, &chunks[1]);
+            .sizes(&[Size::Fixed(70), Size::Min(1)])
+            .render(term, area, |term, chunks| {
+                // TODO: Draw system detailed information.
+                let systems = &galaxy.systems();
+                match self.selected {
+                    Some(point) => {
+                        draw_system_info(galaxy.system(&point).unwrap(), term, &chunks[0])
+                    }
+                    _ => {}
                 }
-                Level::System => {
-                    let system = &galaxy.systems()[self.selected_system];
-                    draw_system_table(self.selected_astronomical, &system, term, &chunks[0]);
-                    draw_system_map(self.selected_astronomical, &system, term, &chunks[1]);
-                }
+                draw_galaxy_map(&self.cursor, &systems, &self.map_scale, term, &chunks[1]);
             });
     }
 }
 
-fn draw_galaxy_table(
-    selected: usize,
-    systems: &Vec<&System>,
-    term: &mut Terminal<MouseBackend>,
-    area: &Rect,
-) {
-    Table::new(
-        ["System", "Faction", "State", "Bodies"].into_iter(),
-        systems
-            .iter()
-            .enumerate()
-            .map(|(idx, ref system)| {
-                let style = match selected == idx {
-                    true => &SELECTED_STYLE,
-                    false => FACTION_STYLES.get(&system.faction).unwrap(),
-                };
-                Row::StyledData(
-                    vec![
-                        system.name.clone(),
-                        system.faction.to_string(),
-                        system.state.to_string(),
-                        (system.satelites.len() as u32).to_string(),
-                    ].into_iter(),
-                    &style,
-                )
-            })
-            .skip(selected),
-    ).block(Block::default().title("System Map").borders(Borders::ALL))
-        .header_style(Style::default().fg(Color::Yellow))
-        .widths(&[30, 15, 10, 5])
-        .render(term, &area);
+/// Draw system ship information for the selected system, if any.
+fn draw_system_info(selected_system: &System, term: &mut Terminal<MouseBackend>, area: &Rect) {
+    let system_data = vec![
+        format!("Faction:   {}", selected_system.faction.to_string()),
+        format!("State:     {}", selected_system.state.to_string()),
+        format!("Star mass: {} M", selected_system.star.mass),
+        format!("Bodies:    {}", selected_system.satelites.len()),
+    ];
+
+    Group::default()
+        .direction(Direction::Vertical)
+        .sizes(&[Size::Fixed(6), Size::Min(1)])
+        .render(term, area, |term, chunks| {
+            SelectableList::default()
+                .items(&system_data)
+                .block(Block::default().title(selected_system.name.clone().as_str()))
+                .style(Style::default().fg(Color::Yellow))
+                .render(term, &chunks[0]);
+            Table::new(
+                // Prepending empty character to get alignment with list above.
+                [" Planet", "Mass", "Orbit distance", "Temperature", "Type"].into_iter(),
+                selected_system.satelites.iter().map(|ref planet| {
+                    let style: &Style = &DEFAULT_STYLE;
+                    Row::StyledData(
+                        vec![
+                            format!(" {}", planet.name.clone()),
+                            planet.mass.to_string(),
+                            planet.orbit_distance.to_string(),
+                            planet.surface_temperature.to_string(),
+                            planet.planet_type.to_string(),
+                        ].into_iter(),
+                        &style,
+                    )
+                }),
+            ).block(Block::default().title("Planets"))
+                .header_style(Style::default().fg(Color::Yellow))
+                .widths(&[15, 5, 15, 15, 5])
+                .render(term, &chunks[1]);
+        });
 }
 
 fn draw_galaxy_map(
-    selected: usize,
+    cursor: &Point,
     systems: &Vec<&System>,
+    map_scale: &f64,
     term: &mut Terminal<MouseBackend>,
     area: &Rect,
 ) {
     // Scale map to not overlap systems.
-    let map_scaling = 20.;
+    let map_scaling = 20. * map_scale;
     let (max_x, max_y) = systems.iter().fold((0., 0.), |(x_max, y_max), s| {
         (
             (s.location.coords.x / map_scaling).abs().max(x_max),
             (s.location.coords.y / map_scaling).abs().max(y_max),
         )
     });
-    let selected_loc = &systems[selected].location;
     Canvas::default()
         .block(Block::default().title("Systems").borders(Borders::ALL))
         .paint(|ctx| {
-            for (idx, system) in systems.iter().enumerate() {
-                let color = match system.faction {
-                    Faction::Empire => Color::Red,
-                    Faction::Federation => Color::Yellow,
-                    Faction::Cartel => Color::Magenta,
-                    Faction::Independent => Color::LightGreen,
-                };
-                match idx == selected {
-                    true => ctx.print(
-                        system.location.coords.x,
-                        system.location.coords.y,
-                        "X",
-                        color,
-                    ),
-                    false => ctx.print(
-                        system.location.coords.x,
-                        system.location.coords.y,
-                        "*",
-                        color,
-                    ),
-                }
+            for system in systems.iter() {
+                let color = FACTION_COLORS.get(&system.faction).unwrap().clone();
+                ctx.print(
+                    system.location.coords.x,
+                    system.location.coords.y,
+                    ".",
+                    color,
+                );
             }
+            ctx.print(cursor.coords.x, cursor.coords.y, "*", Color::Yellow);
         })
-        .x_bounds([selected_loc.coords.x - max_x, selected_loc.coords.x + max_x])
-        .y_bounds([selected_loc.coords.y - max_y, selected_loc.coords.y + max_y])
+        .x_bounds([cursor.coords.x - max_x, cursor.coords.x + max_x])
+        .y_bounds([cursor.coords.y - max_y, cursor.coords.y + max_y])
         .render(term, &area);
-}
-
-fn draw_system_table(
-    selected: usize,
-    system: &System,
-    term: &mut Terminal<MouseBackend>,
-    area: &Rect,
-) {
-    Table::new(
-        ["Planets", "Mass", "Orbit distance", "Temperature", "Type"].into_iter(),
-        system
-            .satelites
-            .iter()
-            .enumerate()
-            .map(|(idx, ref planet)| {
-                let style: &Style = match selected == idx {
-                    true => &SELECTED_STYLE,
-                    false => &DEFAULT_STYLE,
-                };
-                Row::StyledData(
-                    vec![
-                        planet.name.clone(),
-                        planet.mass.to_string(),
-                        planet.orbit_distance.to_string(),
-                        planet.surface_temperature.to_string(),
-                        planet.planet_type.to_string(),
-                    ].into_iter(),
-                    &style,
-                )
-            })
-            .skip(selected),
-    ).block(Block::default().title(&system.name).borders(Borders::ALL))
-        .header_style(Style::default().fg(Color::Yellow))
-        .widths(&[15, 5, 15, 15, 5])
-        .render(term, &area);
-}
-
-fn draw_system_map(
-    selected: usize,
-    system: &System,
-    term: &mut Terminal<MouseBackend>,
-    area: &Rect,
-) {
-    // TODO: Find decent presentation of a system, ascii art?
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,10 +1,10 @@
 use std::hash::{Hash, Hasher};
 
-use nalgebra::geometry::Point3;
+use nalgebra::geometry::Point2;
 use spade::PointN;
 
 /// Alias for 3D Point from nalgebra.
-pub type Point = Point3<f64>;
+pub type Point = Point2<f64>;
 
 /// Wrapper type implementing hashing for Point etc.
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
@@ -23,7 +23,7 @@ impl Hash for HashablePoint {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.0
             .iter()
-            .zip(&[73856093f64, 19349663f64, 83492791f64])
+            .zip(&[73856093f64, 19349663f64])
             .map(|(&a, &b)| (a * b) as u64)
             .fold(0, |acc, val| acc ^ val)
             .hash(state);
@@ -36,7 +36,7 @@ impl PointN for HashablePoint {
     type Scalar = f64;
 
     fn dimensions() -> usize {
-        3
+        2
     }
 
     fn nth(&self, index: usize) -> &Self::Scalar {
@@ -48,7 +48,7 @@ impl PointN for HashablePoint {
 
     fn from_value(value: Self::Scalar) -> HashablePoint {
         HashablePoint {
-            0: Point::new(value, value, value),
+            0: Point::new(value, value),
         }
     }
 }


### PR DESCRIPTION
### Description
Rework the galaxy map to let the player manually move the "cursor".
Moves the system space to 2d to make it easier to visualize and control, particularly in the galaxy map. 

### Alternate Designs
N/A

### Benefits
Better control for the user.

### Possible Drawbacks
N/A

### Applicable Issues
#82 