### PR TITLE
Add faction specific ships

### DIFF
--- a/res/ships.json
+++ b/res/ships.json
@@ -21,6 +21,7 @@
         {
         "name" : "Shamshir",
         "manufacturer" : "Lèon de la Serre",
+        "faction": "Empire",
         "kind" : "Corvette",
         "description" : "The Shamshir is a classic Lèon design which have survived the centuries, with the first production vessel being constructed in 7128. This ship offers great jump range and cargo space in a discrete, well rounded package.",
         "integrity" : 320,
@@ -39,6 +40,7 @@
         {
         "name" : "Dao",
         "manufacturer" : "Lèon de la Serre",
+        "faction": "Empire",
         "kind" : "Corvette",
         "description" : "The Dao is the pride of Lèon de La Serre's shipyards. Originally designed by Lèon himself, the Dao represents his life's work. However, the first vessel was only produce the last century due to technological limits of the time. It represents the pinnacle of imperial might and technology with its incredible cargo space and jump range, while at the same time packing a punch.",
         "integrity" : 840,

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -81,7 +81,12 @@ impl Gui {
                         self.tabs[self.selected_tab].handle_event(evt);
                     }
                 },
-                _ => {}
+                _ => {
+                    // Forward all general events to all tabs.
+                    self.tabs
+                        .iter_mut()
+                        .for_each(|tab| tab.handle_event(evt.clone()));
+                }
             }
         }
         term.show_cursor().unwrap();

--- a/src/ship/mod.rs
+++ b/src/ship/mod.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use resources::ShipResource;
 use entities::Faction;
+use astronomicals::system::System;
 
 /// Ship currently owned by the player.
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -107,9 +108,18 @@ impl Shipyard {
     }
 
     /// Get all available ships.
-    pub fn get_available(&self) -> &Vec<ShipCharacteristics> {
-        // TODO: Base the return value on the caller, i.e the faction, system etc.
-        &self.ships
+    pub fn get_available(&self, system: &System) -> Vec<ShipCharacteristics> {
+        self.ships
+            .iter()
+            .cloned()
+            .filter(|ref ship| {
+                // Only return if the faction matches, if any faction is specified.
+                if let Some(ref faction) = ship.faction {
+                    return *faction == system.faction;
+                }
+                true
+            })
+            .collect::<Vec<_>>()
     }
 
     /// Create a new starting ship.

--- a/src/ship/mod.rs
+++ b/src/ship/mod.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use resources::ShipResource;
+use entities::Faction;
 
 /// Ship currently owned by the player.
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -39,6 +40,7 @@ impl Ship {
 pub struct ShipCharacteristics {
     pub name: String,
     pub manufacturer: String,
+    pub faction: Option<Faction>,
     pub kind: ShipType,
     pub description: String,
     pub integrity: u32,


### PR DESCRIPTION
### Changes
The following PR introduces the following changes:
* Add optional specifier to enable faction specific ships (only accessed in system aligned with that faction)
* Filter shipyard resutls based on current system. Currently only show neutral ships and those specific to the system faction.

### Applicable Issues
N/A
