### PR TITLE
Add system security

### DIFF
--- a/src/astronomicals/system.rs
+++ b/src/astronomicals/system.rs
@@ -14,6 +14,7 @@ pub struct System {
     pub location: Point,
     pub name: String,
     pub faction: Faction,
+    pub security: SystemSecurity,
     pub state: SystemState,
     pub star: Star,
     pub satelites: Vec<Planet>,
@@ -32,6 +33,27 @@ impl PartialEq for System {
 }
 
 impl Eq for System {}
+
+/// Represents the different security levels a system is in at a given point.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum SystemSecurity {
+    Anarchy,
+    Low,
+    Medium,
+    High,
+}
+
+impl fmt::Display for SystemSecurity {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let security_str = match self {
+            &SystemSecurity::Anarchy => "Anarchy",
+            &SystemSecurity::Low => "Low",
+            &SystemSecurity::Medium => "Medium",
+            &SystemSecurity::High => "High",
+        };
+        write!(f, "{}", security_str)
+    }
+}
 
 /// Represents the different states a system is in at a given point.
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/generators/mod.rs
+++ b/src/generators/mod.rs
@@ -16,7 +16,7 @@ pub mod planets;
 use utils::{HashablePoint, Point};
 use resources::{fetch_resource, AstronomicalNamesResource};
 use astronomicals::{hash, Galaxy};
-use astronomicals::system::{SystemBuilder, SystemState};
+use astronomicals::system::{SystemBuilder, SystemSecurity, SystemState};
 use game_config::GameConfig;
 use generators::stars::StarGen;
 use generators::names::NameGen;
@@ -218,10 +218,26 @@ pub fn generate_system(
         })
         .collect();
 
+    // Set the security level based on faction and a probability.
+    let random_val: f64 = rng.gen();
+    let security_level = match faction {
+        Faction::Empire if random_val < 0.5 => SystemSecurity::High,
+        Faction::Empire if random_val >= 0.5 => SystemSecurity::Medium,
+        Faction::Federation if random_val < 0.4 => SystemSecurity::Low,
+        Faction::Federation if random_val < 0.8 => SystemSecurity::Medium,
+        Faction::Federation if random_val >= 0.8 => SystemSecurity::High,
+        Faction::Cartel if random_val < 0.5 => SystemSecurity::Medium,
+        Faction::Cartel if random_val >= 0.5 => SystemSecurity::Anarchy,
+        Faction::Independent if random_val < 0.5 => SystemSecurity::Anarchy,
+        Faction::Independent if random_val >= 0.5 => SystemSecurity::Low,
+        _ => SystemSecurity::Low,
+    };
+
     let mut system = SystemBuilder::default();
     system
         .location(location)
         .faction(faction)
+        .security(security_level)
         .state(SystemState::Boom)
         .star(star);
     (system, satelites)

--- a/src/gui/tab/map.rs
+++ b/src/gui/tab/map.rs
@@ -92,6 +92,7 @@ impl MapTab {
         let system_data = vec![
             format!("Faction:   {}", system.faction.to_string()),
             format!("State:     {}", system.state.to_string()),
+            format!("Security:  {}", system.security.to_string()),
             format!(
                 "Distance:  {:.1} ly",
                 distance(player_loc, &system.location)


### PR DESCRIPTION
### Changes
The following PR introduces the following changes:
* Adds a SystemSecurity type which represents the security level of a given system at one point
* Generation and assignment of security during generation based on the faction and some probability.

### Applicable Issues
N/A
