### PR TITLE
Add initial planet populations

### DIFF
--- a/src/astronomicals/planet.rs
+++ b/src/astronomicals/planet.rs
@@ -1,6 +1,5 @@
 use rand::Rng;
-use statrs::distribution::{Distribution, Exponential, Gamma};
-use generators::Gen;
+use statrs::distribution::{Continuous, Gamma};
 use std::f64::consts::PI;
 use std::fmt;
 
@@ -13,6 +12,7 @@ pub struct Planet {
     pub name: String,
     pub mass: f64,
     pub gravity: f64,
+    pub population: f64,
     pub orbit_distance: f64,
     pub surface_temperature: f64,
     pub planet_type: PlanetType,
@@ -43,6 +43,19 @@ impl fmt::Display for PlanetType {
 }
 
 impl Planet {
+    /// Calculates the initial planet population based on mass and planet type.
+    pub fn initial_population(mass: f64, kind: &PlanetType) -> f64 {
+        let mass_factor = Gamma::new(7., 5.).unwrap();
+        let type_factor: f64 = match kind {
+            &PlanetType::Metal => 150.,
+            &PlanetType::Earth => 800.0,
+            &PlanetType::Rocky => 1.,
+            &PlanetType::Icy => 0.5,
+            &PlanetType::GasGiant => 0.,
+        };
+        mass_factor.pdf(mass) * type_factor * 6.
+    }
+
     /// Calculate planet surface temperature from star luminosity and distance
     /// to it. Uses the Bond albedo for the Earth.
     pub fn calculate_surface_temperature(orbit_distance: f64, star: &Star) -> f64 {
@@ -57,7 +70,7 @@ impl Planet {
         // Earth-like planets at a higher rate.
         let random_val: f64 = rng.gen();
         match (surface_temperature, mass) {
-            (x, y) if x < 124.5 && y >= 5.185 => PlanetType::GasGiant,
+            (_, y) if y >= 5.185 => PlanetType::GasGiant,
             (x, y) if x < 124.5 && y < 5.185 => PlanetType::Icy,
             (x, _) if x > 280. && x < 310. => PlanetType::Earth,
             (x, _) if x >= 124.5 && random_val < 0.8 => PlanetType::Rocky,

--- a/src/generators/mod.rs
+++ b/src/generators/mod.rs
@@ -211,9 +211,11 @@ pub fn generate_system(
             let mass = builder.mass.unwrap();
             let surface_temperature =
                 Planet::calculate_surface_temperature(builder.orbit_distance.unwrap(), &star);
+            let planet_type = Planet::predict_type(&mut rng, surface_temperature, mass);
             builder
                 .surface_temperature(surface_temperature)
-                .planet_type(Planet::predict_type(&mut rng, surface_temperature, mass));
+                .population(Planet::initial_population(mass, &planet_type))
+                .planet_type(planet_type);
             builder
         })
         .collect();

--- a/src/gui/tab/map.rs
+++ b/src/gui/tab/map.rs
@@ -122,13 +122,14 @@ impl MapTab {
                     .render(term, &chunks[0]);
                 Table::new(
                     // Prepending empty character to get alignment with list above.
-                    [" Planet", "Mass", "Temperature", "Type"].into_iter(),
+                    [" Planet", "Mass", "Population", "Temperature", "Type"].into_iter(),
                     system.satelites.iter().map(|ref planet| {
                         let style: &Style = &DEFAULT_STYLE;
                         Row::StyledData(
                             vec![
                                 format!(" {}", planet.name.clone()),
                                 format!("{:.1}", planet.mass),
+                                format!("{:.1} M", planet.population),
                                 format!("{:.1}", planet.surface_temperature),
                                 planet.planet_type.to_string(),
                             ].into_iter(),
@@ -137,7 +138,7 @@ impl MapTab {
                     }),
                 ).block(Block::default().title("Planets"))
                     .header_style(Style::default().fg(Color::Yellow))
-                    .widths(&[15, 5, 15, 15, 5])
+                    .widths(&[15, 5, 15, 15, 10])
                     .render(term, &chunks[1]);
             });
     }
@@ -286,7 +287,7 @@ impl Tab for MapTab {
         let galaxy = self.state.galaxy.lock().unwrap();
         Group::default()
             .direction(Direction::Horizontal)
-            .sizes(&[Size::Fixed(60), Size::Min(1)])
+            .sizes(&[Size::Fixed(75), Size::Min(1)])
             .render(term, area, |term, chunks| {
                 // TODO: Draw system detailed information.
                 let systems = &galaxy.systems();


### PR DESCRIPTION
### Changes
The following PR introduces the following changes:
* Add initial planet populations based on the type of planet an its size. Earthlike and metal planets are prioritized, also planets with similar gravity as earth are more populated.

### Applicable Issues

Enter any applicable Issues here
