### PR TITLE
Minor refactor

### DIFF
--- a/src/astronomicals/mod.rs
+++ b/src/astronomicals/mod.rs
@@ -1,8 +1,6 @@
-use std::collections::{BinaryHeap, HashMap};
+use std::{collections::{BinaryHeap, HashMap}, u32::MAX};
 use spade::rtree::RTree;
 use nalgebra::distance;
-use std::u32::MAX;
-use std::cmp::Ordering;
 
 use utils::{edit_distance, HashablePoint, OrdPoint, Point};
 

--- a/src/astronomicals/mod.rs
+++ b/src/astronomicals/mod.rs
@@ -53,17 +53,6 @@ impl Galaxy {
         self.systems.values().collect::<Vec<_>>()
     }
 
-    /// Returns references to all systems ordered by distance to the given point.
-    pub fn systems_ordered(&self, location: &Point) -> Vec<&system::System> {
-        let mut systems = self.systems.values().collect::<Vec<_>>();
-        systems.sort_unstable_by(|a, b| {
-            distance(location, &a.location)
-                .partial_cmp(&distance(location, &b.location))
-                .unwrap()
-        });
-        systems
-    }
-
     /// Returns mutable references to all systems.
     pub fn systems_mut(&mut self) -> Vec<&mut system::System> {
         self.systems.values_mut().collect::<Vec<_>>()

--- a/src/astronomicals/planet.rs
+++ b/src/astronomicals/planet.rs
@@ -1,7 +1,6 @@
 use rand::Rng;
 use statrs::distribution::{Continuous, Gamma};
-use std::f64::consts::PI;
-use std::fmt;
+use std::{fmt, f64::consts::PI};
 
 use astronomicals::star::Star;
 

--- a/src/astronomicals/planet.rs
+++ b/src/astronomicals/planet.rs
@@ -1,8 +1,4 @@
-use rand::Rng;
-use statrs::distribution::{Continuous, Gamma};
-use std::{fmt, f64::consts::PI};
-
-use astronomicals::star::Star;
+use std::fmt;
 
 #[derive(Serialize, Deserialize, Debug, Builder, Clone)]
 #[builder(field(public))]
@@ -38,43 +34,5 @@ impl fmt::Display for PlanetType {
             &PlanetType::Earth => "Earth",
         };
         write!(f, "{}", security_str)
-    }
-}
-
-impl Planet {
-    /// Calculates the initial planet population based on mass and planet type.
-    pub fn initial_population(mass: f64, kind: &PlanetType) -> f64 {
-        let mass_factor = Gamma::new(7., 5.).unwrap();
-        let type_factor: f64 = match kind {
-            &PlanetType::Metal => 150.,
-            &PlanetType::Earth => 800.0,
-            &PlanetType::Rocky => 1.,
-            &PlanetType::Icy => 0.5,
-            &PlanetType::GasGiant => 0.,
-        };
-        mass_factor.pdf(mass) * type_factor * 6.
-    }
-
-    /// Calculate planet surface temperature from star luminosity and distance
-    /// to it. Uses the Bond albedo for the Earth.
-    pub fn calculate_surface_temperature(orbit_distance: f64, star: &Star) -> f64 {
-        (star.luminosity * 3.846 * 10f64.powi(26) * (1. - 0.29)
-            / (16. * PI * (299692458. * orbit_distance).powi(2) * 5.670373 * 10f64.powi(-8)))
-            .powf(0.25)
-    }
-
-    /// Predict the planet type based on surface_temperature and mass.
-    pub fn predict_type<R: Rng>(rng: &mut R, surface_temperature: f64, mass: f64) -> PlanetType {
-        // Based on trained decision tree with modifications to allow for
-        // Earth-like planets at a higher rate.
-        let random_val: f64 = rng.gen();
-        match (surface_temperature, mass) {
-            (_, y) if y >= 5.185 => PlanetType::GasGiant,
-            (x, y) if x < 124.5 && y < 5.185 => PlanetType::Icy,
-            (x, _) if x > 280. && x < 310. => PlanetType::Earth,
-            (x, _) if x >= 124.5 && random_val < 0.8 => PlanetType::Rocky,
-            (x, _) if x >= 124.5 && random_val >= 0.8 => PlanetType::Metal,
-            _ => PlanetType::Rocky,
-        }
     }
 }

--- a/src/astronomicals/sector.rs
+++ b/src/astronomicals/sector.rs
@@ -1,5 +1,4 @@
 use utils::Point;
-
 use entities::Faction;
 
 /// Represents a group of systems in close proximity within the same faction.

--- a/src/astronomicals/system.rs
+++ b/src/astronomicals/system.rs
@@ -1,10 +1,7 @@
-use std::hash::{Hash, Hasher};
-use std::fmt;
+use std::{fmt, hash::{Hash, Hasher}};
 use utils::Point;
 use entities::Faction;
-use astronomicals::hash;
-use astronomicals::star::Star;
-use astronomicals::planet::Planet;
+use astronomicals::{hash, planet::Planet, star::Star};
 
 #[derive(Serialize, Deserialize, Debug, Builder, Clone)]
 #[builder(field(public))]

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,12 +1,5 @@
-use std::sync::mpsc::{channel, Receiver, Sender};
-use std::sync::Arc;
-use std::io;
-use std::thread;
-use std::sync::Mutex;
-
-use termion::event;
-use termion::input::TermRead;
-
+use std::{io, thread, sync::{Arc, Mutex, mpsc::{channel, Receiver, Sender}}};
+use termion::{event, input::TermRead};
 use game::Game;
 
 /// User and system events.

--- a/src/game.rs
+++ b/src/game.rs
@@ -1,6 +1,4 @@
-use std::sync::Mutex;
-use std::sync::Arc;
-use std::fs::{create_dir_all, File};
+use std::{fs::{create_dir_all, File}, sync::{Arc, Mutex}};
 use preferences::prefs_base_dir;
 use serde_cbor::{from_reader, to_writer};
 

--- a/src/game_config.rs
+++ b/src/game_config.rs
@@ -1,11 +1,8 @@
+use std::{fs::{create_dir_all, File}, io::{Read, Write}, sync::mpsc::{channel, RecvError},
+          time::Duration};
 use preferences::prefs_base_dir;
 use notify::{watcher, RecursiveMode, Watcher};
-use std::sync::mpsc::{channel, RecvError};
-use std::time::Duration;
-use std::fs::{create_dir_all, File};
-use std::io::{Read, Write};
-use toml::ser::to_string_pretty;
-use toml::de::from_str;
+use toml::{de::from_str, ser::to_string_pretty};
 
 const PREFS_PATH: &str = "gemini/conf/";
 

--- a/src/generators/mod.rs
+++ b/src/generators/mod.rs
@@ -202,11 +202,11 @@ pub fn generate_system(
             let mut builder = planet_gen.generate(&mut rng).unwrap();
             let mass = builder.mass.unwrap();
             let surface_temperature =
-                Planet::calculate_surface_temperature(builder.orbit_distance.unwrap(), &star);
-            let planet_type = Planet::predict_type(&mut rng, surface_temperature, mass);
+                PlanetGen::calculate_surface_temperature(builder.orbit_distance.unwrap(), &star);
+            let planet_type = PlanetGen::predict_type(&mut rng, surface_temperature, mass);
             builder
                 .surface_temperature(surface_temperature)
-                .population(Planet::initial_population(mass, &planet_type))
+                .population(PlanetGen::initial_population(mass, &planet_type))
                 .planet_type(planet_type);
             builder
         })

--- a/src/generators/mod.rs
+++ b/src/generators/mod.rs
@@ -17,40 +17,6 @@ pub mod names;
 pub mod stars;
 pub mod planets;
 
-/// A generator that can be explicitly seeded in order to the produce the same
-/// stream of psuedo randomness each time.
-pub trait SeedableGenerator {
-    /// Reseed a generator with the given seed.
-    fn reseed(&mut self, seed: u32);
-
-    /// Create a new generator with the given seed.
-    fn from_seed(seed: u32) -> Self;
-}
-
-/// A generator which can be trained by provided some training resource.
-pub trait TrainableGenerator {
-    type TrainRes;
-
-    /// Train the generator with the given data.
-    fn train(&mut self, &Self::TrainRes);
-}
-
-/// Generic mutable Generator, may modify the generator after generating an item.
-pub trait MutGen: TrainableGenerator + SeedableGenerator {
-    type GenItem;
-
-    /// Generate a new item from the generator, can be None if the generator is empty etc.
-    fn generate(&mut self) -> Option<Self::GenItem>;
-}
-
-/// Generic Generator, does not modify the generator instead uses provided random number generator.
-pub trait Gen {
-    type GenItem;
-
-    /// Generate a new item from the generator, can be None if the generator is empty etc.
-    fn generate<R: Rng>(&self, gen: &mut R) -> Option<Self::GenItem>;
-}
-
 /// Generate a galaxy with systems etc, will use the provided config to guide
 /// the generation.
 pub fn generate_galaxy(config: &GameConfig) -> Galaxy {

--- a/src/generators/mod.rs
+++ b/src/generators/mod.rs
@@ -1,22 +1,18 @@
-use std::{collections::HashMap, f64, iter::FromIterator, sync::{Arc, Mutex}, time::Instant,
-          usize::MAX};
-use rand::{seq, ChaChaRng, Rng, SeedableRng};
+use std::{sync::{Arc, Mutex}, time::Instant};
+use rand::{ChaChaRng, Rng, SeedableRng};
 use rayon::prelude::*;
 use statrs::distribution::{Distribution, Normal};
-use nalgebra::distance;
 
 use utils::{HashablePoint, Point};
 use resources::{fetch_resource, AstronomicalNamesResource};
-use astronomicals::{hash, Galaxy, planet::{Planet, PlanetBuilder}, sector::Sector,
-                    system::SystemBuilder};
-use generators::names::NameGen;
+use astronomicals::{hash, Galaxy, planet::{Planet, PlanetBuilder}, system::SystemBuilder};
 use game_config::GameConfig;
-use entities::Faction;
 
 pub mod names;
 pub mod stars;
 pub mod planets;
 pub mod systems;
+pub mod sectors;
 
 /// Generate a galaxy with systems etc, will use the provided config to guide
 /// the generation.
@@ -46,7 +42,8 @@ pub fn generate_galaxy(config: &GameConfig) -> Galaxy {
     let name_gen = Arc::new(Mutex::new(name_gen_unwraped));
 
     // Generate sectors
-    let sectors = into_sectors(
+    let sector_gen = sectors::SectorGen::new();
+    let sectors = sector_gen.generate(
         config,
         name_gen.clone(),
         locations
@@ -131,177 +128,4 @@ pub fn generate_galaxy(config: &GameConfig) -> Galaxy {
     );
 
     Galaxy::new(sectors, systems)
-}
-
-/// Split the systems in to a set number of clusters using K-means.
-fn into_sectors(
-    config: &GameConfig,
-    name_gen: Arc<Mutex<NameGen>>,
-    system_locations: Vec<HashablePoint>,
-) -> Vec<Sector> {
-    // Measure time for generation.
-    let now = Instant::now();
-
-    info!("Simulating expansion for initial sectors...");
-    let seed: &[_] = &[config.map_seed as u32];
-    let mut rng: ChaChaRng = SeedableRng::from_seed(seed);
-
-    // Setup initial centroids
-    let mut centroids =
-        seq::sample_iter(&mut rng, system_locations.iter(), config.number_of_sectors)
-            .unwrap()
-            .into_iter()
-            .map(|system_location| system_location.as_point().clone())
-            .collect::<Vec<_>>();
-
-    // Split data into two sets if using approximation
-    let mut idx = 0;
-    let (cluster_set, rest): (Vec<HashablePoint>, Vec<HashablePoint>) =
-        system_locations.into_iter().partition(|_| {
-            idx += 1;
-            idx < config.num_approximation_systems || !config.sector_approximation
-        });
-
-    // System to cluster_id mapping
-    let mut cluster_map: HashMap<HashablePoint, usize> =
-        HashMap::from_iter(cluster_set.into_iter().map(|point| (point, 0)));
-
-    debug!("Initial centroids: {:#?}", centroids);
-
-    // Run K means until convergence, i.e until no reassignments
-    let mut has_assigned = true;
-    while has_assigned {
-        let wrapped_assigned = Mutex::new(false);
-
-        // Assign to closest centroid
-        cluster_map
-            .par_iter_mut()
-            .for_each(|(system_location, cluster_id)| {
-                let mut closest_cluster = *cluster_id;
-                let mut closest_distance =
-                    distance(system_location.as_point(), &centroids[*cluster_id]);
-                for i in 0..centroids.len() {
-                    let distance = distance(system_location.as_point(), &centroids[i]);
-                    if distance < closest_distance {
-                        *wrapped_assigned.lock().unwrap() = true;
-                        closest_cluster = i;
-                        closest_distance = distance;
-                    }
-                }
-                *cluster_id = closest_cluster;
-            });
-
-        has_assigned = *wrapped_assigned.lock().unwrap();
-
-        // Calculate new centroids
-        centroids
-            //.par_iter_mut()
-            .iter_mut()
-            .enumerate()
-            .for_each(|(id, centroid)| {
-                let mut count = 0.;
-                let mut new_centroid = Point::origin();
-                for (system_location, _) in cluster_map.iter().filter(|&(_, c_id)| *c_id == id) {
-                    new_centroid += system_location.as_point().coords;
-                    count += 1.;
-                }
-                new_centroid *= 1. / count;
-                *centroid = new_centroid;
-            });
-    }
-
-    // Setup cluster vectors
-    let mut sector_vecs =
-        (0..config.number_of_sectors).fold(Vec::<Vec<HashablePoint>>::new(), |mut sectors, _| {
-            sectors.push(vec![]);
-            sectors
-        });
-
-    // Map systems to final cluster
-    for (system_location, id) in cluster_map.into_iter() {
-        sector_vecs[id].push(system_location);
-    }
-
-    // Assign remaining systems to closest centroid if any left
-    rest.into_iter().for_each(|system_location| {
-        let mut closest_cluster = 0;
-        let mut closest_distance = f64::MAX;
-        for i in 0..centroids.len() {
-            let distance = distance(system_location.as_point(), &centroids[i]);
-            if distance < closest_distance {
-                closest_cluster = i;
-                closest_distance = distance;
-            }
-        }
-        sector_vecs[closest_cluster].push(system_location);
-    });
-
-    // Unwrap and lock name generator as it is mutated by generation.
-    let mut name_gen_unwraped = name_gen.lock().unwrap();
-
-    // Create sector for each cluster
-    let sectors = sector_vecs
-        .into_iter()
-        .map(|system_locations| {
-            let sector_seed: &[_] = &[system_locations.len() as u32];
-            let mut faction_rng: ChaChaRng = SeedableRng::from_seed(sector_seed);
-            name_gen_unwraped.reseed(*sector_seed.first().unwrap());
-            Sector {
-                system_locations: system_locations
-                    .into_iter()
-                    .map(|hashpoint| hashpoint.as_point().clone())
-                    .collect::<Vec<_>>(),
-                name: name_gen_unwraped
-                    .generate()
-                    .unwrap_or(String::from("Unnamed")),
-                faction: Faction::random_faction(&mut faction_rng),
-            }
-        })
-        .collect::<Vec<Sector>>();
-
-    info!(
-        "Mapped galaxy into {} sectors of {} systems, avg size: {}, 
-          max size {}, min size {}, taking {} ms \n 
-          Sectors include: {} Cartel, {} Empire, {} Federation, {} Independent",
-        sectors.len(),
-        sectors
-            .iter()
-            .fold(0, |acc, ref sec| acc + sec.system_locations.len()),
-        sectors
-            .iter()
-            .fold(0, |acc, ref sec| acc + sec.system_locations.len()) / sectors.len(),
-        sectors
-            .iter()
-            .fold(0, |acc, ref sec| acc.max(sec.system_locations.len())),
-        sectors
-            .iter()
-            .fold(MAX, |acc, ref sec| acc.min(sec.system_locations.len())),
-        ((now.elapsed().as_secs() * 1_000) + (now.elapsed().subsec_nanos() / 1_000_000) as u64),
-        sectors
-            .iter()
-            .fold(0, |acc, ref sec| acc + match sec.faction {
-                Faction::Cartel => 1,
-                _ => 0,
-            }),
-        sectors
-            .iter()
-            .fold(0, |acc, ref sec| acc + match sec.faction {
-                Faction::Empire => 1,
-                _ => 0,
-            }),
-        sectors
-            .iter()
-            .fold(0, |acc, ref sec| acc + match sec.faction {
-                Faction::Federation => 1,
-                _ => 0,
-            }),
-        sectors
-            .iter()
-            .fold(0, |acc, ref sec| acc + match sec.faction {
-                Faction::Independent => 1,
-                _ => 0,
-            })
-    );
-
-    sectors
 }

--- a/src/generators/mod.rs
+++ b/src/generators/mod.rs
@@ -1,29 +1,21 @@
+use std::{collections::HashMap, f64, iter::FromIterator, sync::{Arc, Mutex}, time::Instant,
+          usize::MAX};
 use rand::{seq, ChaChaRng, Rng, SeedableRng};
-use std::time::Instant;
-use std::collections::HashMap;
 use rayon::prelude::*;
 use statrs::distribution::{Distribution, Normal, Poisson};
 use nalgebra::distance;
-use std::sync::{Arc, Mutex};
-use std::iter::FromIterator;
-use std::usize::MAX;
-use std::f64;
+
+use utils::{HashablePoint, Point};
+use resources::{fetch_resource, AstronomicalNamesResource};
+use astronomicals::{hash, Galaxy, planet::{Planet, PlanetBuilder}, sector::Sector,
+                    system::{Reputation, SystemBuilder, SystemSecurity, SystemState}};
+use generators::{names::NameGen, planets::PlanetGen, stars::StarGen};
+use game_config::GameConfig;
+use entities::Faction;
 
 pub mod names;
 pub mod stars;
 pub mod planets;
-
-use utils::{HashablePoint, Point};
-use resources::{fetch_resource, AstronomicalNamesResource};
-use astronomicals::{hash, Galaxy};
-use astronomicals::system::{Reputation, SystemBuilder, SystemSecurity, SystemState};
-use game_config::GameConfig;
-use generators::stars::StarGen;
-use generators::names::NameGen;
-use generators::planets::PlanetGen;
-use astronomicals::planet::{Planet, PlanetBuilder};
-use astronomicals::sector::Sector;
-use entities::Faction;
 
 /// A generator that can be explicitly seeded in order to the produce the same
 /// stream of psuedo randomness each time.

--- a/src/generators/names.rs
+++ b/src/generators/names.rs
@@ -2,7 +2,6 @@ use std::{cmp::max, collections::{BTreeSet, HashSet}};
 use rand::{IsaacRng, Rng, SeedableRng};
 use inflector::Inflector;
 use petgraph::{Graph, prelude::NodeIndex};
-use generators::{MutGen, SeedableGenerator, TrainableGenerator};
 use resources::AstronomicalNamesResource;
 
 /// Basic non deterministic name generator for generating random strings which
@@ -16,9 +15,9 @@ pub struct NameGen {
     suffixes: Vec<String>,
 }
 
-impl SeedableGenerator for NameGen {
+impl NameGen {
     /// Creates a new NameGen with the given seed.
-    fn from_seed(seed: u32) -> NameGen {
+    pub fn from_seed(seed: u32) -> NameGen {
         // Create and initialize random generator using seed.
         let new_seed: &[_] = &[seed];
         let rng: IsaacRng = SeedableRng::from_seed(new_seed);
@@ -39,19 +38,15 @@ impl SeedableGenerator for NameGen {
     }
 
     /// Creates a new NameGen with the given seed.
-    fn reseed(&mut self, seed: u32) {
+    pub fn reseed(&mut self, seed: u32) {
         // Create and initialize random generator using seed.
         let new_seed: &[_] = &[seed];
         let rng: IsaacRng = SeedableRng::from_seed(new_seed);
         self.rng = rng;
     }
-}
-
-impl TrainableGenerator for NameGen {
-    type TrainRes = AstronomicalNamesResource;
 
     /// Trains the underlying model using the given AstronomicalNamesResource.
-    fn train(&mut self, data: &AstronomicalNamesResource) {
+    pub fn train(&mut self, data: &AstronomicalNamesResource) {
         let depth = data.names.iter().fold(0, |acc, ref s| max(acc, s.len()));
 
         // Instansiate layers, number of layers is equal to the longest training
@@ -94,17 +89,13 @@ impl TrainableGenerator for NameGen {
         self.suffixes.extend_from_slice(&data.greek[..]);
         self.suffixes.extend_from_slice(&data.decorators[..]);
     }
-}
-
-impl MutGen for NameGen {
-    type GenItem = String;
 
     /// Attempts to generate a new name from the model.
     /// This name is guaranteed to exist in the training set or to have been
     /// previously generated.
     /// Attempts N number of tries, if no unique name could be found it will
     /// return None.
-    fn generate(&mut self) -> Option<String> {
+    pub fn generate(&mut self) -> Option<String> {
         // Non deterministicly generate a new string from the model.
         // Note: This may produce an exisiting string in the training set or
         // previously generated set.

--- a/src/generators/names.rs
+++ b/src/generators/names.rs
@@ -1,9 +1,7 @@
+use std::{cmp::max, collections::{BTreeSet, HashSet}};
 use rand::{IsaacRng, Rng, SeedableRng};
-use std::cmp::max;
-use std::collections::{BTreeSet, HashSet};
 use inflector::Inflector;
-use petgraph::Graph;
-use petgraph::prelude::NodeIndex;
+use petgraph::{Graph, prelude::NodeIndex};
 use generators::{MutGen, SeedableGenerator, TrainableGenerator};
 use resources::AstronomicalNamesResource;
 

--- a/src/generators/planets.rs
+++ b/src/generators/planets.rs
@@ -1,7 +1,9 @@
 use rand::Rng;
-use statrs::distribution::{Distribution, Exponential, Gamma};
+use statrs::distribution::{Continuous, Distribution, Exponential, Gamma};
+use std::f64::consts::PI;
+
 use generators::Gen;
-use astronomicals::planet::PlanetBuilder;
+use astronomicals::{planet::{PlanetBuilder, PlanetType}, star::Star};
 
 /// Basic non deterministic name generator for generating new Planets which
 /// are similar to the trained data provided.
@@ -22,6 +24,42 @@ impl PlanetGen {
         PlanetGen {
             mass_gen,
             orbit_dist_gen,
+        }
+    }
+
+    /// Calculates the initial planet population based on mass and planet type.
+    pub fn initial_population(mass: f64, kind: &PlanetType) -> f64 {
+        let mass_factor = Gamma::new(7., 5.).unwrap();
+        let type_factor: f64 = match kind {
+            &PlanetType::Metal => 150.,
+            &PlanetType::Earth => 800.0,
+            &PlanetType::Rocky => 1.,
+            &PlanetType::Icy => 0.5,
+            &PlanetType::GasGiant => 0.,
+        };
+        mass_factor.pdf(mass) * type_factor * 6.
+    }
+
+    /// Calculate planet surface temperature from star luminosity and distance
+    /// to it. Uses the Bond albedo for the Earth.
+    pub fn calculate_surface_temperature(orbit_distance: f64, star: &Star) -> f64 {
+        (star.luminosity * 3.846 * 10f64.powi(26) * (1. - 0.29)
+            / (16. * PI * (299692458. * orbit_distance).powi(2) * 5.670373 * 10f64.powi(-8)))
+            .powf(0.25)
+    }
+
+    /// Predict the planet type based on surface_temperature and mass.
+    pub fn predict_type<R: Rng>(rng: &mut R, surface_temperature: f64, mass: f64) -> PlanetType {
+        // Based on trained decision tree with modifications to allow for
+        // Earth-like planets at a higher rate.
+        let random_val: f64 = rng.gen();
+        match (surface_temperature, mass) {
+            (_, y) if y >= 5.185 => PlanetType::GasGiant,
+            (x, y) if x < 124.5 && y < 5.185 => PlanetType::Icy,
+            (x, _) if x > 280. && x < 310. => PlanetType::Earth,
+            (x, _) if x >= 124.5 && random_val < 0.8 => PlanetType::Rocky,
+            (x, _) if x >= 124.5 && random_val >= 0.8 => PlanetType::Metal,
+            _ => PlanetType::Rocky,
         }
     }
 }

--- a/src/generators/planets.rs
+++ b/src/generators/planets.rs
@@ -2,7 +2,6 @@ use rand::Rng;
 use statrs::distribution::{Continuous, Distribution, Exponential, Gamma};
 use std::f64::consts::PI;
 
-use generators::Gen;
 use astronomicals::{planet::{PlanetBuilder, PlanetType}, star::Star};
 
 /// Basic non deterministic name generator for generating new Planets which
@@ -62,14 +61,10 @@ impl PlanetGen {
             _ => PlanetType::Rocky,
         }
     }
-}
-
-impl Gen for PlanetGen {
-    type GenItem = PlanetBuilder;
 
     /// Generates a new PlanetBuilder from the _distribution_ using the provided random
     /// generator. Sets the fields which are independent on the context.
-    fn generate<R: Rng>(&self, gen: &mut R) -> Option<PlanetBuilder> {
+    pub fn generate<R: Rng>(&self, gen: &mut R) -> Option<PlanetBuilder> {
         let mass = self.mass_gen.sample(gen);
 
         // Magic constant, needed to scale back since scaling needed to fit gamma.

--- a/src/generators/sectors.rs
+++ b/src/generators/sectors.rs
@@ -1,0 +1,199 @@
+use std::{collections::HashMap, f64, iter::FromIterator, sync::{Arc, Mutex}, time::Instant,
+          usize::MAX};
+use rand::{seq, ChaChaRng, SeedableRng};
+use rayon::prelude::*;
+use nalgebra::distance;
+
+use utils::{HashablePoint, Point};
+use astronomicals::sector::Sector;
+use generators::names::NameGen;
+use game_config::GameConfig;
+use entities::Faction;
+
+/// Used for generating sectors.
+pub struct SectorGen {}
+
+impl SectorGen {
+    /// Create a new sector generator.
+    pub fn new() -> SectorGen {
+        SectorGen {}
+    }
+
+    /// Split the systems in to a set number of clusters using K-means.
+    pub fn generate(
+        &self,
+        config: &GameConfig,
+        name_gen: Arc<Mutex<NameGen>>,
+        system_locations: Vec<HashablePoint>,
+    ) -> Vec<Sector> {
+        // Measure time for generation.
+        let now = Instant::now();
+
+        info!("Simulating expansion for initial sectors...");
+        let seed: &[_] = &[config.map_seed as u32];
+        let mut rng: ChaChaRng = SeedableRng::from_seed(seed);
+
+        // Setup initial centroids
+        let mut centroids =
+            seq::sample_iter(&mut rng, system_locations.iter(), config.number_of_sectors)
+                .unwrap()
+                .into_iter()
+                .map(|system_location| system_location.as_point().clone())
+                .collect::<Vec<_>>();
+
+        // Split data into two sets if using approximation
+        let mut idx = 0;
+        let (cluster_set, rest): (Vec<HashablePoint>, Vec<HashablePoint>) =
+            system_locations.into_iter().partition(|_| {
+                idx += 1;
+                idx < config.num_approximation_systems || !config.sector_approximation
+            });
+
+        // System to cluster_id mapping
+        let mut cluster_map: HashMap<HashablePoint, usize> =
+            HashMap::from_iter(cluster_set.into_iter().map(|point| (point, 0)));
+
+        debug!("Initial centroids: {:#?}", centroids);
+
+        // Run K means until convergence, i.e until no reassignments
+        let mut has_assigned = true;
+        while has_assigned {
+            let wrapped_assigned = Mutex::new(false);
+
+            // Assign to closest centroid
+            cluster_map
+                .par_iter_mut()
+                .for_each(|(system_location, cluster_id)| {
+                    let mut closest_cluster = *cluster_id;
+                    let mut closest_distance =
+                        distance(system_location.as_point(), &centroids[*cluster_id]);
+                    for i in 0..centroids.len() {
+                        let distance = distance(system_location.as_point(), &centroids[i]);
+                        if distance < closest_distance {
+                            *wrapped_assigned.lock().unwrap() = true;
+                            closest_cluster = i;
+                            closest_distance = distance;
+                        }
+                    }
+                    *cluster_id = closest_cluster;
+                });
+
+            has_assigned = *wrapped_assigned.lock().unwrap();
+
+            // Calculate new centroids
+            centroids
+                //.par_iter_mut()
+                .iter_mut()
+                .enumerate()
+                .for_each(|(id, centroid)| {
+                    let mut count = 0.;
+                    let mut new_centroid = Point::origin();
+                    for (system_location, _) in cluster_map.iter()
+                        .filter(|&(_, c_id)| *c_id == id) {
+                            new_centroid += system_location.as_point().coords;
+                            count += 1.;
+                        }
+                    new_centroid *= 1. / count;
+                    *centroid = new_centroid;
+                });
+        }
+
+        // Setup cluster vectors
+        let mut sector_vecs = (0..config.number_of_sectors).fold(
+            Vec::<Vec<HashablePoint>>::new(),
+            |mut sectors, _| {
+                sectors.push(vec![]);
+                sectors
+            },
+        );
+
+        // Map systems to final cluster
+        for (system_location, id) in cluster_map.into_iter() {
+            sector_vecs[id].push(system_location);
+        }
+
+        // Assign remaining systems to closest centroid if any left
+        rest.into_iter().for_each(|system_location| {
+            let mut closest_cluster = 0;
+            let mut closest_distance = f64::MAX;
+            for i in 0..centroids.len() {
+                let distance = distance(system_location.as_point(), &centroids[i]);
+                if distance < closest_distance {
+                    closest_cluster = i;
+                    closest_distance = distance;
+                }
+            }
+            sector_vecs[closest_cluster].push(system_location);
+        });
+
+        // Unwrap and lock name generator as it is mutated by generation.
+        let mut name_gen_unwraped = name_gen.lock().unwrap();
+
+        // Create sector for each cluster
+        let sectors = sector_vecs
+            .into_iter()
+            .map(|system_locations| {
+                let sector_seed: &[_] = &[system_locations.len() as u32];
+                let mut faction_rng: ChaChaRng = SeedableRng::from_seed(sector_seed);
+                name_gen_unwraped.reseed(*sector_seed.first().unwrap());
+                Sector {
+                    system_locations: system_locations
+                        .into_iter()
+                        .map(|hashpoint| hashpoint.as_point().clone())
+                        .collect::<Vec<_>>(),
+                    name: name_gen_unwraped
+                        .generate()
+                        .unwrap_or(String::from("Unnamed")),
+                    faction: Faction::random_faction(&mut faction_rng),
+                }
+            })
+            .collect::<Vec<Sector>>();
+
+        info!(
+            "Mapped galaxy into {} sectors of {} systems, avg size: {}, 
+          max size {}, min size {}, taking {} ms \n 
+          Sectors include: {} Cartel, {} Empire, {} Federation, {} Independent",
+            sectors.len(),
+            sectors
+                .iter()
+                .fold(0, |acc, ref sec| acc + sec.system_locations.len()),
+            sectors
+                .iter()
+                .fold(0, |acc, ref sec| acc + sec.system_locations.len())
+                / sectors.len(),
+            sectors
+                .iter()
+                .fold(0, |acc, ref sec| acc.max(sec.system_locations.len())),
+            sectors
+                .iter()
+                .fold(MAX, |acc, ref sec| acc.min(sec.system_locations.len())),
+            ((now.elapsed().as_secs() * 1_000) + (now.elapsed().subsec_nanos() / 1_000_000) as u64),
+            sectors
+                .iter()
+                .fold(0, |acc, ref sec| acc + match sec.faction {
+                    Faction::Cartel => 1,
+                    _ => 0,
+                }),
+            sectors
+                .iter()
+                .fold(0, |acc, ref sec| acc + match sec.faction {
+                    Faction::Empire => 1,
+                    _ => 0,
+                }),
+            sectors
+                .iter()
+                .fold(0, |acc, ref sec| acc + match sec.faction {
+                    Faction::Federation => 1,
+                    _ => 0,
+                }),
+            sectors
+                .iter()
+                .fold(0, |acc, ref sec| acc + match sec.faction {
+                    Faction::Independent => 1,
+                    _ => 0,
+                })
+        );
+
+        sectors
+    }
+}

--- a/src/generators/stars.rs
+++ b/src/generators/stars.rs
@@ -1,6 +1,5 @@
 use rand;
 use statrs::distribution::{Distribution, Gamma};
-use generators::Gen;
 use astronomicals::star::{Star, StarType};
 
 /// Basic non deterministic name generator for generating new Stars.
@@ -14,14 +13,10 @@ impl StarGen {
         let mass_gen = Gamma::new(2., 1.5).unwrap();
         StarGen { mass_gen }
     }
-}
-
-impl Gen for StarGen {
-    type GenItem = Star;
 
     /// Generates a new Star from the _distribution_ using the provided random
     /// generator.
-    fn generate<R: rand::Rng>(&self, gen: &mut R) -> Option<Star> {
+    pub fn generate<R: rand::Rng>(&self, gen: &mut R) -> Option<Star> {
         // Do not want too small stars.
         let mass = self.mass_gen.sample(gen).max(0.1);
 

--- a/src/generators/systems.rs
+++ b/src/generators/systems.rs
@@ -1,0 +1,94 @@
+use std::f64;
+use rand::{ChaChaRng, Rng, SeedableRng};
+use statrs::distribution::{Distribution, Poisson};
+
+use utils::Point;
+use astronomicals::{hash, planet::PlanetBuilder,
+                    system::{Reputation, SystemBuilder, SystemSecurity, SystemState}};
+use generators::{planets::PlanetGen, stars::StarGen};
+use entities::Faction;
+
+/// Used for generating systems.
+pub struct SystemGen {
+    num_planets_gen: Poisson,
+    star_gen: StarGen,
+    planet_gen: PlanetGen,
+}
+
+impl SystemGen {
+    /// Create a new system generator.
+    pub fn new() -> SystemGen {
+        // Create Star generator.
+        let star_gen = StarGen::new();
+
+        // Create Planet generator.
+        let planet_gen = PlanetGen::new();
+
+        SystemGen {
+            num_planets_gen: Poisson::new(3.).unwrap(),
+            star_gen,
+            planet_gen,
+        }
+    }
+
+    /// Generate a new star system at the given location with the given faction.
+    pub fn generate(
+        &self,
+        location: Point,
+        faction: Faction,
+    ) -> (SystemBuilder, Vec<PlanetBuilder>) {
+        // Calculate hash.
+        let hash = hash(&location);
+        let seed: &[_] = &[hash as u32];
+        let mut rng: ChaChaRng = SeedableRng::from_seed(seed);
+
+        let star = self.star_gen.generate(&mut rng).unwrap();
+
+        // TODO: Replace constant in config.
+        let num_planets =
+            (self.num_planets_gen.sample::<ChaChaRng>(&mut rng).round() as u32).max(1);
+
+        // Fallback to planet name: Unnamed if no name could be generated.
+        let satelites: Vec<PlanetBuilder> = (0..num_planets)
+            .map(|_| {
+                let mut builder = self.planet_gen.generate(&mut rng).unwrap();
+                let mass = builder.mass.unwrap();
+                let surface_temperature = PlanetGen::calculate_surface_temperature(
+                    builder.orbit_distance.unwrap(),
+                    &star,
+                );
+                let planet_type = PlanetGen::predict_type(&mut rng, surface_temperature, mass);
+                builder
+                    .surface_temperature(surface_temperature)
+                    .population(PlanetGen::initial_population(mass, &planet_type))
+                    .planet_type(planet_type);
+                builder
+            })
+            .collect();
+
+        // Set the security level based on faction and a probability.
+        let random_val: f64 = rng.gen();
+        let security_level = match faction {
+            Faction::Empire if random_val < 0.5 => SystemSecurity::High,
+            Faction::Empire if random_val >= 0.5 => SystemSecurity::Medium,
+            Faction::Federation if random_val < 0.4 => SystemSecurity::Low,
+            Faction::Federation if random_val < 0.8 => SystemSecurity::Medium,
+            Faction::Federation if random_val >= 0.8 => SystemSecurity::High,
+            Faction::Cartel if random_val < 0.5 => SystemSecurity::Medium,
+            Faction::Cartel if random_val >= 0.5 => SystemSecurity::Anarchy,
+            Faction::Independent if random_val < 0.5 => SystemSecurity::Anarchy,
+            Faction::Independent if random_val >= 0.5 => SystemSecurity::Low,
+            _ => SystemSecurity::Low,
+        };
+
+        let mut system = SystemBuilder::default();
+        system
+            .location(location)
+            .faction(faction)
+            .security(security_level)
+            .state(SystemState::Boom)
+            .reputation(Reputation::default())
+            .star(star);
+        (system, satelites)
+    }
+}

--- a/src/gui/eventbox.rs
+++ b/src/gui/eventbox.rs
@@ -1,8 +1,5 @@
-use tui::Terminal;
-use tui::backend::MouseBackend;
-use tui::widgets::{Block, Borders, Paragraph, Widget};
-use tui::layout::Rect;
-use tui::style::{Color, Style};
+use tui::{Terminal, backend::MouseBackend, layout::Rect, style::{Color, Style},
+          widgets::{Block, Borders, Paragraph, Widget}};
 use std::time::Instant;
 
 use event::Event;

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1,18 +1,13 @@
-use std::io;
-use std::sync::Arc;
-
-use tui::Terminal;
-use tui::backend::MouseBackend;
+use std::{io, sync::Arc};
+use tui::{Terminal, backend::MouseBackend, layout::{Direction, Group, Rect, Size},
+          style::{Color, Style}, widgets::{Block, Borders, Tabs, Widget}};
 use termion::event as keyevent;
-use tui::widgets::{Block, Borders, Tabs, Widget};
-use tui::layout::{Direction, Group, Rect, Size};
-use tui::style::{Color, Style};
-
-mod tab;
-mod eventbox;
 
 use game::Game;
 use event::{add_autosave_handler, add_keyboard_handler, Event, HANDLER};
+
+mod tab;
+mod eventbox;
 
 /// Handles the graphical user interface to the user.
 pub struct Gui {

--- a/src/gui/tab/map.rs
+++ b/src/gui/tab/map.rs
@@ -2,13 +2,12 @@ use super::*;
 use std::collections::HashMap;
 use termion::event as keyevent;
 use nalgebra::{distance, Vector2};
+use tui::{layout::{Direction, Group, Rect, Size}, style::{Color, Style},
+          widgets::{Block, Borders, Paragraph, Row, SelectableList, Table, Widget, canvas::Canvas}};
+
 use utils::Point;
-use entities::Faction;
 use astronomicals::system::System;
-use tui::widgets::{Block, Borders, Paragraph, Row, SelectableList, Table, Widget};
-use tui::widgets::canvas::Canvas;
-use tui::layout::{Direction, Group, Rect, Size};
-use tui::style::{Color, Style};
+use entities::Faction;
 
 lazy_static! {
     /// Color mapping for each faction.

--- a/src/gui/tab/mod.rs
+++ b/src/gui/tab/mod.rs
@@ -1,9 +1,5 @@
-use std::sync::Arc;
-use std::sync::mpsc::Sender;
-
-use tui::Terminal;
-use tui::backend::MouseBackend;
-use tui::layout::Rect;
+use std::sync::{Arc, mpsc::Sender};
+use tui::{Terminal, backend::MouseBackend, layout::Rect};
 
 use game::Game;
 use event::{Event, HANDLER};

--- a/src/gui/tab/shipyard.rs
+++ b/src/gui/tab/shipyard.rs
@@ -1,9 +1,8 @@
 use super::*;
 use std::iter;
 use termion::event as keyevent;
-use tui::widgets::{Block, Borders, Paragraph, SelectableList, Widget};
-use tui::layout::{Direction, Group, Rect, Size};
-use tui::style::{Color, Style};
+use tui::{layout::{Direction, Group, Rect, Size}, style::{Color, Style},
+          widgets::{Block, Borders, Paragraph, SelectableList, Widget}};
 use textwrap::fill;
 
 use ship::ShipCharacteristics;

--- a/src/gui/tab/status.rs
+++ b/src/gui/tab/status.rs
@@ -1,8 +1,8 @@
 use super::*;
+use tui::{layout::{Direction, Group, Rect, Size}, style::{Color, Style},
+          widgets::{Block, Borders, Paragraph, SelectableList, Widget}};
+
 use player::Player;
-use tui::widgets::{Block, Borders, Paragraph, SelectableList, Widget};
-use tui::layout::{Direction, Group, Rect, Size};
-use tui::style::{Color, Style};
 
 /// Displays the status tab.
 pub struct StatusTab {

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -1,7 +1,6 @@
-use std::str;
+use std::{str, collections::HashMap};
 use serde_json;
 use serde::de::Deserialize;
-use std::collections::HashMap;
 
 use ship::ShipCharacteristics;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,4 @@
-use std::hash::{Hash, Hasher};
-use std::cmp::{min, Ordering};
-use std::mem::swap;
+use std::{cmp::{min, Ordering}, hash::{Hash, Hasher}, mem::swap};
 
 use nalgebra::geometry::Point2;
 use spade::PointN;


### PR DESCRIPTION
### Changes
The following PR introduces the following changes:
* Clean up some imports using new feature in Rust 1.25
* Remove unneeded traits used in generation.
* Move generate_system and into_sectors to seperate generators to make it more consistent with genration of planets and stars.

### Applicable Issues

Enter any applicable Issues here
