### PR TITLE
Filter out logging from external crates

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,7 @@ mod ship;
 mod utils;
 mod player;
 
+use log::LevelFilter;
 use app_dirs::{get_data_root, AppDataType};
 use generators::generate_galaxy;
 
@@ -55,7 +56,8 @@ pub fn setup_logger() -> Result<(), fern::InitError> {
                 message
             ))
         })
-        .level(log::LevelFilter::Debug)
+        .level(log::LevelFilter::Off)
+        .level_for("gemini", LevelFilter::Trace)
         .chain(fern::log_file(output_path)?)
         .apply()?;
     Ok(())


### PR DESCRIPTION
### Changes
The following PR introduces the following changes:
* Logging will only include messages from this crate, no other external logs as it bloats the log file.

### Applicable Issues
N/A