### PR TITLE
Remove duplicate draw of tabs to avoid layered draw

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -109,7 +109,6 @@ impl Gui {
                     .highlight_style(Style::default().fg(Color::Yellow))
                     .select(self.selected_tab)
                     .render(term, &chunks[0]);
-                self.tabs[self.selected_tab].draw(term, &chunks[1]);
                 // Draw dialog or current tab.
                 match self.dialog {
                     Some(ref dialog) => dialog.draw(term, &chunks[1]),


### PR DESCRIPTION
### Changes
The following PR introduces the following changes:
* Remove redundant draw call which causes issues since we have overlapping draws on the same area. Instead we only draw the tab or the dialog

### Applicable Issues
N/A
