### PR TITLE
Implement system map functionality

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -16,7 +16,7 @@ pub enum Event {
     Undock(usize),
     AutosaveStarted,
     AutosaveCompleted,
-    OpenDialog(Box<Dialog>),
+    OpenDialog(Arc<Mutex<Dialog>>),
     CloseDialog,
 }
 

--- a/src/gui/dialog/mod.rs
+++ b/src/gui/dialog/mod.rs
@@ -4,6 +4,10 @@ use termion::event as keyevent;
 
 use event::{Event, HANDLER};
 
+mod planet;
+
+pub use self::planet::PlanetDialog;
+
 /// A dialog box.
 pub trait Dialog: Send {
     /// Returns the title string describing the dialog box.

--- a/src/gui/dialog/mod.rs
+++ b/src/gui/dialog/mod.rs
@@ -18,13 +18,4 @@ pub trait Dialog: Send {
 
     /// Draws the dialog in the given terminal and area.
     fn draw(&self, term: &mut Terminal<MouseBackend>, area: &Rect);
-
-    /// Returns a deep clone as box.
-    fn box_clone(&self) -> Box<Dialog>;
-}
-
-impl Clone for Box<Dialog> {
-    fn clone(&self) -> Box<Dialog> {
-        self.box_clone()
-    }
 }

--- a/src/gui/dialog/mod.rs
+++ b/src/gui/dialog/mod.rs
@@ -4,9 +4,9 @@ use termion::event as keyevent;
 
 use event::{Event, HANDLER};
 
-mod planet;
+mod multi;
 
-pub use self::planet::PlanetDialog;
+pub use self::multi::MultiDialog;
 
 /// A dialog box.
 pub trait Dialog: Send {

--- a/src/gui/dialog/multi.rs
+++ b/src/gui/dialog/multi.rs
@@ -3,36 +3,29 @@ use std::sync::Mutex;
 use tui::{layout::{Direction, Group, Rect, Size}, style::{Color, Style},
           widgets::{Block, Borders, Paragraph, SelectableList, Widget}};
 
-use player::PlayerState;
+type Action = Fn() -> Event + Send + Sync;
 
-/// Dialog window representing options available when interacting with a planet.
-pub struct PlanetDialog {
+/// Multiple choice dialog window.
+pub struct MultiDialog {
     sender: Sender<Event>,
-    planetid: usize,
     title: String,
     selected: usize,
-    buttons: Vec<&'static str>,
+    actions: Vec<(&'static str, Box<Action>)>,
 }
 
-impl PlanetDialog {
+impl MultiDialog {
     /// Create a new PlanetDialog.
-    pub fn new(planetid: usize, is_landed: bool, title: String) -> Arc<Mutex<Self>> {
-        let buttons = match is_landed {
-            true => vec!["Refuel", "Undock"],
-            false => vec!["Dock"],
-        };
-
-        Arc::new(Mutex::new(PlanetDialog {
+    pub fn new(title: String, actions: Vec<(&'static str, Box<Action>)>) -> Arc<Mutex<Self>> {
+        Arc::new(Mutex::new(MultiDialog {
             sender: HANDLER.send_handle(),
-            planetid,
             title,
             selected: 0,
-            buttons,
+            actions,
         }))
     }
 }
 
-impl Dialog for PlanetDialog {
+impl Dialog for MultiDialog {
     /// Returns the title string describing the dialog box.
     fn title(&self) -> String {
         self.title.clone()
@@ -46,24 +39,14 @@ impl Dialog for PlanetDialog {
                     // Move up.
                     keyevent::Key::Char('k') => self.selected.max(1) - 1,
                     // Move down.
-                    keyevent::Key::Char('j') => (self.selected + 1).min(self.buttons.len() - 1),
+                    keyevent::Key::Char('j') => (self.selected + 1).min(self.actions.len() - 1),
                     _ => self.selected,
                 };
                 match input {
                     keyevent::Key::Char('\n') => {
-                        // Send the correct event.
-                        match self.buttons[self.selected] {
-                            "Refuel" => {
-                                self.sender.send(Event::Refuel);
-                            }
-                            "Undock" => {
-                                self.sender.send(Event::Undock(self.planetid));
-                            }
-                            "Dock" => {
-                                self.sender.send(Event::Dock(self.planetid));
-                            }
-                            _ => {}
-                        };
+                        // Call the appropriate action.
+                        let (_, ref action_fn) = self.actions[self.selected];
+                        self.sender.send(action_fn());
                         self.sender.send(Event::CloseDialog);
                     }
                     keyevent::Key::Backspace => {
@@ -79,22 +62,18 @@ impl Dialog for PlanetDialog {
     /// Draws the dialog in the given terminal and area.
     fn draw(&self, term: &mut Terminal<MouseBackend>, area: &Rect) {
         let dialog_rect = Rect::new((area.width - 60) / 2, (area.height - 5) / 2, 60, 5);
-        let labels: Vec<String> = self.buttons
+        let labels: Vec<String> = self.actions
             .iter()
-            .map(|s| format!("{:^1$}", s, 60))
+            .map(|&(s, _)| format!("{:^1$}", s, 60))
             .collect::<Vec<_>>();
         Group::default()
             .direction(Direction::Vertical)
-            .sizes(&[Size::Fixed(self.buttons.len() as u16)])
+            .sizes(&[Size::Fixed(self.actions.len() as u16)])
             .render(term, &dialog_rect, |term, chunks| {
                 SelectableList::default()
                     .items(&labels)
                     .select(self.selected)
-                    .block(
-                        Block::default()
-                            .borders(Borders::ALL)
-                            .title(&format!("Planet: {}", &self.title)),
-                    )
+                    .block(Block::default().borders(Borders::ALL).title(&self.title))
                     .style(Style::default().fg(Color::Green).bg(Color::DarkGray))
                     .highlight_style(Style::default().fg(Color::Yellow).bg(Color::Gray))
                     .render(term, &chunks[0]);

--- a/src/gui/dialog/planet.rs
+++ b/src/gui/dialog/planet.rs
@@ -1,0 +1,108 @@
+use super::*;
+use tui::{layout::{Direction, Group, Rect, Size}, style::{Color, Style},
+          widgets::{Block, Borders, Paragraph, SelectableList, Widget}};
+
+use player::PlayerState;
+
+/// Dialog window representing options available when interacting with a planet.
+#[derive(Clone)]
+pub struct PlanetDialog {
+    sender: Sender<Event>,
+    planetid: usize,
+    title: String,
+    selected: usize,
+    buttons: Vec<&'static str>,
+}
+
+impl PlanetDialog {
+    /// Create a new PlanetDialog.
+    pub fn new(planetid: usize, is_landed: bool, title: String) -> Box<Self> {
+        let buttons = match is_landed {
+            true => vec!["Refuel", "Undock"],
+            false => vec!["Dock"],
+        };
+
+        Box::new(PlanetDialog {
+            sender: HANDLER.send_handle(),
+            planetid,
+            title,
+            selected: 0,
+            buttons,
+        })
+    }
+}
+
+impl Dialog for PlanetDialog {
+    /// Returns the title string describing the dialog box.
+    fn title(&self) -> String {
+        self.title.clone()
+    }
+
+    /// Handles the user provided event.
+    fn handle_event(&mut self, event: Event) {
+        match event {
+            Event::Input(input) => {
+                self.selected = match input {
+                    // Move up.
+                    keyevent::Key::Char('k') => self.selected.max(1) - 1,
+                    // Move down.
+                    keyevent::Key::Char('j') => (self.selected + 1).min(self.buttons.len() - 1),
+                    _ => self.selected,
+                };
+                match input {
+                    keyevent::Key::Char('\n') => {
+                        // Send the correct event.
+                        match self.buttons[self.selected] {
+                            "Refuel" => {
+                                self.sender.send(Event::Refuel);
+                            }
+                            "Undock" => {
+                                self.sender.send(Event::Undock(self.planetid));
+                            }
+                            "Dock" => {
+                                self.sender.send(Event::Dock(self.planetid));
+                            }
+                            _ => {}
+                        };
+                        self.sender.send(Event::CloseDialog);
+                    }
+                    keyevent::Key::Backspace => {
+                        self.sender.send(Event::CloseDialog);
+                    }
+                    _ => {}
+                };
+            }
+            _ => {}
+        };
+    }
+
+    /// Draws the dialog in the given terminal and area.
+    fn draw(&self, term: &mut Terminal<MouseBackend>, area: &Rect) {
+        let dialog_rect = Rect::new((area.width - 60) / 2, (area.height - 5) / 2, 60, 5);
+        let labels: Vec<String> = self.buttons
+            .iter()
+            .map(|s| format!("{:^1$}", s, 60))
+            .collect::<Vec<_>>();
+        Group::default()
+            .direction(Direction::Vertical)
+            .sizes(&[Size::Fixed(self.buttons.len() as u16)])
+            .render(term, &dialog_rect, |term, chunks| {
+                SelectableList::default()
+                    .items(&labels)
+                    .select(self.selected)
+                    .block(
+                        Block::default()
+                            .borders(Borders::ALL)
+                            .title(&format!("Planet: {}", &self.title)),
+                    )
+                    .style(Style::default().fg(Color::Green).bg(Color::DarkGray))
+                    .highlight_style(Style::default().fg(Color::Yellow).bg(Color::Gray))
+                    .render(term, &chunks[0]);
+            });
+    }
+
+    /// Returns a deep clone.
+    fn box_clone(&self) -> Box<Dialog> {
+        Box::new((*self).clone())
+    }
+}

--- a/src/gui/dialog/planet.rs
+++ b/src/gui/dialog/planet.rs
@@ -1,11 +1,11 @@
 use super::*;
+use std::sync::Mutex;
 use tui::{layout::{Direction, Group, Rect, Size}, style::{Color, Style},
           widgets::{Block, Borders, Paragraph, SelectableList, Widget}};
 
 use player::PlayerState;
 
 /// Dialog window representing options available when interacting with a planet.
-#[derive(Clone)]
 pub struct PlanetDialog {
     sender: Sender<Event>,
     planetid: usize,
@@ -16,19 +16,19 @@ pub struct PlanetDialog {
 
 impl PlanetDialog {
     /// Create a new PlanetDialog.
-    pub fn new(planetid: usize, is_landed: bool, title: String) -> Box<Self> {
+    pub fn new(planetid: usize, is_landed: bool, title: String) -> Arc<Mutex<Self>> {
         let buttons = match is_landed {
             true => vec!["Refuel", "Undock"],
             false => vec!["Dock"],
         };
 
-        Box::new(PlanetDialog {
+        Arc::new(Mutex::new(PlanetDialog {
             sender: HANDLER.send_handle(),
             planetid,
             title,
             selected: 0,
             buttons,
-        })
+        }))
     }
 }
 
@@ -99,10 +99,5 @@ impl Dialog for PlanetDialog {
                     .highlight_style(Style::default().fg(Color::Yellow).bg(Color::Gray))
                     .render(term, &chunks[0]);
             });
-    }
-
-    /// Returns a deep clone.
-    fn box_clone(&self) -> Box<Dialog> {
-        Box::new((*self).clone())
     }
 }

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -4,7 +4,7 @@ use tui::{Terminal, backend::MouseBackend, layout::{Direction, Group, Rect, Size
 use termion::event as keyevent;
 
 use game::Game;
-use event::{add_autosave_handler, add_keyboard_handler, add_update_handler, Event, HANDLER};
+use event::{add_keyboard_handler, add_player_handler, add_update_handler, Event, HANDLER};
 
 mod tab;
 pub mod dialog;
@@ -23,7 +23,7 @@ impl Gui {
         // TODO: Make a bit more elegant
         add_keyboard_handler();
         // TODO: Move to some where more reasonable.
-        add_autosave_handler(game.clone());
+        add_player_handler(game.clone());
         // TODO: Move to some where more reasonable.
         add_update_handler(game.clone());
 

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1,4 +1,4 @@
-use std::{io, sync::Arc};
+use std::{io, sync::{Arc, Mutex}};
 use tui::{Terminal, backend::MouseBackend, layout::{Direction, Group, Rect, Size},
           style::{Color, Style}, widgets::{Block, Borders, Tabs, Widget}};
 use termion::event as keyevent;
@@ -14,7 +14,7 @@ pub struct Gui {
     size: Rect,
     tabs: Vec<Box<tab::Tab>>,
     selected_tab: usize,
-    dialog: Option<Box<dialog::Dialog>>,
+    dialog: Option<Arc<Mutex<dialog::Dialog>>>,
 }
 
 impl Gui {
@@ -73,7 +73,7 @@ impl Gui {
                     _ => {
                         // Forward event to current tab or dialog if open.
                         match self.dialog {
-                            Some(ref mut dialog) => dialog.handle_event(evt),
+                            Some(ref dialog) => dialog.lock().unwrap().handle_event(evt),
                             _ => self.tabs[self.selected_tab].handle_event(evt),
                         };
                     }
@@ -111,7 +111,7 @@ impl Gui {
                     .render(term, &chunks[0]);
                 // Draw dialog or current tab.
                 match self.dialog {
-                    Some(ref dialog) => dialog.draw(term, &chunks[1]),
+                    Some(ref dialog) => dialog.lock().unwrap().draw(term, &chunks[1]),
                     None => self.tabs[self.selected_tab].draw(term, &chunks[1]),
                 }
             });

--- a/src/gui/tab/galaxymap.rs
+++ b/src/gui/tab/galaxymap.rs
@@ -28,8 +28,8 @@ lazy_static! {
 /// The minimum distance within which the gui will snap to the closest system.
 const MIN_SNAP_DIST: f64 = 0.9;
 
-/// Displays the map tab.
-pub struct MapTab {
+/// Displays the galaxy map tab.
+pub struct GalaxyMapTab {
     state: Arc<Game>,
     sender: Sender<Event>,
     search_mode: bool,
@@ -40,7 +40,7 @@ pub struct MapTab {
     map_scale: f64,
 }
 
-impl MapTab {
+impl GalaxyMapTab {
     /// Attempts to find a route to the selected system.
     fn find_route(&mut self) {
         let galaxy = &self.state.galaxy.lock().unwrap();
@@ -227,11 +227,11 @@ impl MapTab {
     }
 }
 
-impl Tab for MapTab {
+impl Tab for GalaxyMapTab {
     /// Creates a map tab.
     fn new(state: Arc<Game>, send_handle: Sender<Event>) -> Box<Self> {
         let cursor = state.player.lock().unwrap().location().clone();
-        Box::new(MapTab {
+        Box::new(GalaxyMapTab {
             state: state,
             sender: send_handle,
             selected: Some(cursor.clone()),

--- a/src/gui/tab/mod.rs
+++ b/src/gui/tab/mod.rs
@@ -6,6 +6,7 @@ use event::{Event, HANDLER};
 
 mod status;
 mod galaxymap;
+mod systemmap;
 mod market;
 mod mission;
 mod shipyard;
@@ -32,6 +33,7 @@ pub fn create_tabs(state: Arc<Game>) -> Vec<Box<Tab>> {
     vec![
         status::StatusTab::new(state.clone(), HANDLER.send_handle()),
         galaxymap::GalaxyMapTab::new(state.clone(), HANDLER.send_handle()),
+        systemmap::SystemMapTab::new(state.clone(), HANDLER.send_handle()),
         market::MarketTab::new(state.clone(), HANDLER.send_handle()),
         mission::MissionTab::new(state.clone(), HANDLER.send_handle()),
         shipyard::ShipyardTab::new(state.clone(), HANDLER.send_handle()),

--- a/src/gui/tab/mod.rs
+++ b/src/gui/tab/mod.rs
@@ -5,7 +5,7 @@ use game::Game;
 use event::{Event, HANDLER};
 
 mod status;
-mod map;
+mod galaxymap;
 mod market;
 mod mission;
 mod shipyard;
@@ -31,7 +31,7 @@ pub trait Tab {
 pub fn create_tabs(state: Arc<Game>) -> Vec<Box<Tab>> {
     vec![
         status::StatusTab::new(state.clone(), HANDLER.send_handle()),
-        map::MapTab::new(state.clone(), HANDLER.send_handle()),
+        galaxymap::GalaxyMapTab::new(state.clone(), HANDLER.send_handle()),
         market::MarketTab::new(state.clone(), HANDLER.send_handle()),
         mission::MissionTab::new(state.clone(), HANDLER.send_handle()),
         shipyard::ShipyardTab::new(state.clone(), HANDLER.send_handle()),

--- a/src/gui/tab/systemmap.rs
+++ b/src/gui/tab/systemmap.rs
@@ -1,0 +1,143 @@
+use super::*;
+use termion::event as keyevent;
+
+use astronomicals::system::System;
+use player::PlayerState;
+use tui::widgets::{Block, Borders, Row, Table, Widget};
+use tui::widgets::canvas::Canvas;
+use tui::layout::{Direction, Group, Rect, Size};
+use tui::style::{Color, Style};
+
+lazy_static! {
+    /// Styling for selected item.
+    static ref SELECTED_STYLE: Style = Style::default().fg(Color::Yellow);
+
+    /// Styling for unselected item.
+    static ref DEFAULT_STYLE: Style = Style::default();
+}
+
+/// Displays the map tab.
+pub struct SystemMapTab {
+    state: Arc<Game>,
+    send_handle: Sender<Event>,
+    selected_astronomical: usize,
+    max_selected_astronomical: usize,
+}
+
+impl SystemMapTab {
+    /// Returns the last index of satelites in the current system, defaults to zero.
+    fn num_astronomicals(state: &Arc<Game>) -> usize {
+        let player = state.player.lock().unwrap();
+        match player.state() {
+            PlayerState::Stationary => {
+                let galaxy = state.galaxy.lock().unwrap();
+                galaxy.system(player.location()).unwrap().satelites.len() - 1
+            }
+            _ => 0,
+        }
+    }
+}
+
+impl Tab for SystemMapTab {
+    /// Creates a system map tab.
+    fn new(state: Arc<Game>, send_handle: Sender<Event>) -> Box<Self> {
+        let max_selected_astronomical = SystemMapTab::num_astronomicals(&state);
+
+        Box::new(SystemMapTab {
+            state: state,
+            send_handle: send_handle,
+            selected_astronomical: 0,
+            max_selected_astronomical: max_selected_astronomical,
+        })
+    }
+
+    /// Returns the title string describing the tab.
+    fn title(&self) -> String {
+        String::from("System Map")
+    }
+
+    /// Handles the user provided event.
+    fn handle_event(&mut self, event: Event) {
+        match event {
+            Event::Input(input) => {
+                self.selected_astronomical = match input {
+                    // Move up.
+                    keyevent::Key::Char('k') => self.selected_astronomical.max(1) - 1,
+                    // Move down.
+                    keyevent::Key::Char('j') => {
+                        (self.selected_astronomical + 1).min(self.max_selected_astronomical)
+                    }
+                    _ => self.selected_astronomical,
+                };
+            }
+            Event::Update => {
+                // Update maximum index if needed.
+                self.max_selected_astronomical = SystemMapTab::num_astronomicals(&self.state);
+            }
+            _ => {}
+        };
+    }
+
+    /// Draws the tab in the given terminal and area.
+    fn draw(&self, term: &mut Terminal<MouseBackend>, area: &Rect) {
+        Group::default()
+            .direction(Direction::Horizontal)
+            .sizes(&[Size::Fixed(75), Size::Percent(70)])
+            .render(term, area, |term, chunks| {
+                let player = self.state.player.lock().unwrap();
+                match player.state() {
+                    PlayerState::Stationary => {
+                        let galaxy = self.state.galaxy.lock().unwrap();
+                        let system = galaxy.system(player.location()).unwrap();
+                        draw_system_table(self.selected_astronomical, &system, term, &chunks[0]);
+                        draw_system_map(self.selected_astronomical, &system, term, &chunks[1]);
+                    }
+                    _ => {}
+                }
+            });
+    }
+}
+
+fn draw_system_table(
+    selected: usize,
+    system: &System,
+    term: &mut Terminal<MouseBackend>,
+    area: &Rect,
+) {
+    Table::new(
+        // Prepending empty character to get alignment with list above.
+        [" Planet", "Mass", "Population", "Temperature", "Type"].into_iter(),
+        system
+            .satelites
+            .iter()
+            .enumerate()
+            .map(|(idx, ref planet)| {
+                let style: &Style = match selected == idx {
+                    true => &SELECTED_STYLE,
+                    false => &DEFAULT_STYLE,
+                };
+                Row::StyledData(
+                    vec![
+                        format!(" {}", planet.name.clone()),
+                        format!("{:.1}", planet.mass),
+                        format!("{:.1} M", planet.population),
+                        format!("{:.1}", planet.surface_temperature),
+                        planet.planet_type.to_string(),
+                    ].into_iter(),
+                    &style,
+                )
+            }),
+    ).block(Block::default().title(&system.name).borders(Borders::ALL))
+        .header_style(Style::default().fg(Color::Yellow))
+        .widths(&[15, 5, 15, 15, 10])
+        .render(term, &area);
+}
+
+fn draw_system_map(
+    selected: usize,
+    system: &System,
+    term: &mut Terminal<MouseBackend>,
+    area: &Rect,
+) {
+    // TODO: Find decent presentation of a system, ascii art?
+}

--- a/src/player.rs
+++ b/src/player.rs
@@ -23,7 +23,7 @@ impl Player {
             credits,
             ship: Some(ship),
             location: location.clone(),
-            state: PlayerState::Stationary,
+            state: PlayerState::InSystem,
         }
     }
 
@@ -34,7 +34,8 @@ impl Player {
         while repeat {
             repeat = false;
             self.state = match self.state {
-                PlayerState::Stationary => PlayerState::Stationary,
+                PlayerState::Docked(planetid) => PlayerState::Docked(planetid),
+                PlayerState::InSystem => PlayerState::InSystem,
                 PlayerState::Traveling {
                     ref start,
                     ref route,
@@ -76,7 +77,7 @@ impl Player {
                             }
                         }
                         // No route left.
-                        None => PlayerState::Stationary,
+                        None => PlayerState::InSystem,
                     }
                 }
             };
@@ -106,6 +107,26 @@ impl Player {
     /// Returns the player state.
     pub fn state(&self) -> PlayerState {
         self.state.clone()
+    }
+
+    /// Docks the player to the planet with the given id.
+    pub fn dock(&mut self, planet_id: usize) {
+        self.state = PlayerState::Docked(planet_id);
+    }
+
+    /// Undocks the player from its current planet.
+    pub fn undock(&mut self) {
+        self.state = PlayerState::InSystem;
+    }
+
+    /// Attemps to fuel up the player ship as far as credits reaches.
+    pub fn refuel(&mut self) {
+        if let Some(ref mut ship) = self.ship {
+            // TODO: Assumes each fuel unit costs 10 credits.
+            let to_fill = (ship.characteristics().fuel - ship.fuel()).min(self.credits / 10);
+            self.credits -= to_fill * 10;
+            ship.add_fuel(to_fill);
+        }
     }
 
     /// Sets the route for the player.
@@ -154,7 +175,7 @@ impl Default for Player {
             credits: 0,
             ship: None,
             location: Point::origin(),
-            state: PlayerState::Stationary,
+            state: PlayerState::InSystem,
         }
     }
 }
@@ -162,7 +183,8 @@ impl Default for Player {
 /// Holds the current state of the player which affects the options of interaction.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum PlayerState {
-    Stationary,
+    InSystem,
+    Docked(usize),
     Traveling {
         start: DateTime<Utc>,
         route: Vec<Point>,

--- a/src/player.rs
+++ b/src/player.rs
@@ -103,6 +103,11 @@ impl Player {
         &self.location
     }
 
+    /// Returns the player state.
+    pub fn state(&self) -> PlayerState {
+        self.state.clone()
+    }
+
     /// Sets the route for the player.
     pub fn set_route(&mut self, route: Vec<Point>) {
         self.state = PlayerState::Traveling {
@@ -156,7 +161,7 @@ impl Default for Player {
 
 /// Holds the current state of the player which affects the options of interaction.
 #[derive(Serialize, Deserialize, Clone, Debug)]
-enum PlayerState {
+pub enum PlayerState {
     Stationary,
     Traveling {
         start: DateTime<Utc>,

--- a/src/ship/mod.rs
+++ b/src/ship/mod.rs
@@ -40,6 +40,11 @@ impl Ship {
         self.fuel -= 1;
     }
 
+    /// Add the given amount to the fuel level.
+    pub fn add_fuel(&mut self, amount: u32) {
+        self.fuel += amount;
+    }
+
     /// Returns a reference to the ship's characteristics.
     pub fn characteristics(&self) -> &ShipCharacteristics {
         &self.base


### PR DESCRIPTION
### Changes
The following PR introduces the following changes:
* Renames the current map to the galaxy map
* Create a basic system map showing the different planets
* Adds dialog and actions to refuel, dock and undock from planets which affects the user state
* Shows information about which planet, if any, the player is docked at in the status tab

### Applicable Issues
N/A
